### PR TITLE
Json: workaroud for PHP fatal error

### DIFF
--- a/src/Utils/Json.php
+++ b/src/Utils/Json.php
@@ -81,8 +81,11 @@ class Json
 			throw new JsonException('Invalid UTF-8 sequence', 5); // workaround for PHP < 5.3.3 & PECL JSON-C
 		}
 
-		$args = array($json, (bool) ($options & self::FORCE_ARRAY));
-		$args[] = 512;
+		$forceArray = (bool) ($options & self::FORCE_ARRAY);
+		if (!$forceArray && preg_match('#(?<=[^\\\\]")\\\\u0000(?:[^"\\\\]|\\\\.)*+"\s*+:#', $json)) { // workaround for json_decode fatal error when object key starts with \u0000
+			throw new JsonException(static::$messages[JSON_ERROR_CTRL_CHAR]);
+		}
+		$args = array($json, $forceArray, 512);
 		if (PHP_VERSION_ID >= 50400 && !(defined('JSON_C_VERSION') && PHP_INT_SIZE > 4)) { // not implemented in PECL JSON-C 1.3.2 for 64bit systems
 			$args[] = JSON_BIGINT_AS_STRING;
 		}

--- a/tests/Utils/Json.decode().phpt
+++ b/tests/Utils/Json.decode().phpt
@@ -37,6 +37,16 @@ Assert::exception(function() {
 
 
 Assert::exception(function() {
+	Json::decode('{"\u0000": 1}');
+}, 'Nette\Utils\JsonException', 'Unexpected control character found');
+
+
+Assert::same( array("\x00" => 1), Json::decode('{"\u0000": 1}', Json::FORCE_ARRAY) );
+Assert::equal( (object) array('a' => "\x00"), Json::decode('{"a": "\u0000"}') );
+Assert::equal( (object) array("\"\x00" => 1), Json::decode('{"\"\u0000": 1}') );
+
+
+Assert::exception(function() {
 	Json::decode("\"\xC1\xBF\"");
 }, 'Nette\Utils\JsonException', 'Invalid UTF-8 sequence');
 


### PR DESCRIPTION
PHP function `json_decode` has a nasty bug which lead to **fatal error** if key starts with a NULL byte. Simple workaround for this is to pass `true` as the second parameter. Any tips how to solve this issue in `Nette\Utils\Json`?

<del>This pull contains only failing test for now.</del> 
