### PR TITLE
[WIP] Json: decode() should always return valid UTF-8 string

### DIFF
--- a/tests/Utils/Json.decode().phpt
+++ b/tests/Utils/Json.decode().phpt
@@ -41,6 +41,11 @@ Assert::exception(function() {
 }, 'Nette\Utils\JsonException', 'Invalid UTF-8 sequence');
 
 
+Assert::exception(function() {
+	Json::decode('"\uD811\uD811"');
+}, 'Nette\Utils\JsonException');
+
+
 // default JSON_BIGINT_AS_STRING
 if (PHP_VERSION_ID >= 50400) {
 	if (defined('JSON_C_VERSION')) {


### PR DESCRIPTION
Again – only failing test. 

Simple and ugly fix would be to check recursively all strings with `Strings::checkEncoding`.

Or we may simple ignore this issue.
