### PR TITLE
Html data attributes

### DIFF
--- a/src/Utils/HtmlDataset.php
+++ b/src/Utils/HtmlDataset.php
@@ -58,7 +58,11 @@ class HtmlDataset extends Nette\Object implements \ArrayAccess, \Countable, \Ite
 	 */
 	public function __set($name, $value)
 	{
-		$this->data[$this->dataKey($name)] = $value;
+		if ($value === NULL) {
+			unset($this->data[$this->dataKey($name)]);
+		} else {
+			$this->data[$this->dataKey($name)] = $value;
+		}
 	}
 
 

--- a/src/Utils/HtmlDataset.php
+++ b/src/Utils/HtmlDataset.php
@@ -1,0 +1,181 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (http://nette.org)
+ * Copyright (c) 2004 David Grudl (http://davidgrudl.com)
+ */
+
+namespace Nette\Utils;
+
+use Nette;
+
+
+/**
+ * HTML dataset helper.
+ *
+ * @author     Petr Morávek <petr@pada.cz>
+ */
+class HtmlDataset extends Nette\Object implements \ArrayAccess, \Countable, \IteratorAggregate, IHtmlString
+{
+	/** @var array */
+	private $data = array();
+
+
+	public function __construct($data = array())
+	{
+		foreach ($data as $name => $value) {
+			$this->data[$this->dataKey($name)] = $value;
+		}
+	}
+
+
+	/**
+	 * @return string
+	 */
+	public function __toString()
+	{
+		$s = '';
+		foreach ($this->data as $k => $v) {
+			if ($v === NULL) {
+				continue;
+			}
+			if (!is_string($v)) {
+				$v = Json::encode($v);
+			}
+			$q = strpos($v, '"') === FALSE ? '"' : "'";
+			$v = $q . str_replace(array('&', $q), array('&amp;', $q === '"' ? '&quot;' : '&#39;'), $v) . $q;
+			$s .= ' data-' . strtolower(preg_replace('#(.)(?=[A-Z])#', '$1-', $k)) . '=' . $v;
+		}
+		return ltrim($s);
+	}
+
+
+	/**
+	 * Overloaded setter for data attribute.
+	 * @param  string    data attribute name
+	 * @param  mixed     data attribute value
+	 * @return void
+	 */
+	public function __set($name, $value)
+	{
+		$this->data[$this->dataKey($name)] = $value;
+	}
+
+
+	/**
+	 * Overloaded getter for data attribute.
+	 * @param  string    data attribute name
+	 * @return mixed     data attribute value
+	 */
+	public function &__get($name)
+	{
+		return $this->data[$this->dataKey($name)];
+	}
+
+
+	/**
+	 * Overloaded tester for data attribute.
+	 * @param  string    data attribute name
+	 * @return bool
+	 */
+	public function __isset($name)
+	{
+		return isset($this->data[$this->dataKey($name)]);
+	}
+
+
+	/**
+	 * Overloaded unsetter for data attribute.
+	 * @param  string    data attribute name
+	 * @return void
+	 */
+	public function __unset($name)
+	{
+		unset($this->data[$this->dataKey($name)]);
+	}
+
+
+	/**
+	 * Inserts (replaces) content for data attribute (\ArrayAccess implementation).
+	 * @param  string name
+	 * @param  mixed data
+	 * @return void
+	 */
+	public function offsetSet($name, $value)
+	{
+		$this->$name = $value;
+	}
+
+
+	/**
+	 * Returns content of data attribute (\ArrayAccess implementation).
+	 * @param  string name
+	 * @return mixed
+	 */
+	public function offsetGet($name)
+	{
+		return $this->$name;
+	}
+
+
+	/**
+	 * Does data attribute exist? (\ArrayAccess implementation).
+	 * @param  string name
+	 * @return bool
+	 */
+	public function offsetExists($name)
+	{
+		return isset($this->$name);
+	}
+
+
+	/**
+	 * Removes data attribute (\ArrayAccess implementation).
+	 * @param  int name
+	 * @return void
+	 */
+	public function offsetUnset($name)
+	{
+		unset($this->$name);
+	}
+
+
+	/**
+	 * Required by the \Countable interface.
+	 * @return int
+	 */
+	public function count()
+	{
+		return count($this->data);
+	}
+
+
+	/**
+	 * Returns an iterator over all items.
+	 * @return \ArrayIterator
+	 */
+	public function getIterator()
+	{
+		return new \ArrayIterator($this->data);
+	}
+
+
+	/**
+	 * Returns camelCase data key.
+	 * @param  string
+	 * @return string
+	 */
+	private function dataKey($s)
+	{
+		if (strpos($s, '-') === FALSE) {
+			return strtolower(substr($s, 0, 1)) . substr($s, 1);
+		}
+
+		$s = strtolower($s);
+		$s = preg_replace('#-(?=[a-z])#', ' ', $s);
+		$s = substr(ucwords('x' . $s), 1);
+		$s = str_replace(' ', '', $s);
+		return $s;
+	}
+
+}

--- a/src/Utils/HtmlDataset.php
+++ b/src/Utils/HtmlDataset.php
@@ -171,11 +171,13 @@ class HtmlDataset extends Nette\Object implements \ArrayAccess, \Countable, \Ite
 			return strtolower(substr($s, 0, 1)) . substr($s, 1);
 		}
 
-		$s = strtolower($s);
-		$s = preg_replace('#-(?=[a-z])#', ' ', $s);
-		$s = substr(ucwords('x' . $s), 1);
-		$s = str_replace(' ', '', $s);
-		return $s;
+		return preg_replace_callback(
+			'#-([a-z])#',
+			function ($m) {
+				return strtoupper($m[1]);
+			},
+			strtolower($s)
+		);
 	}
 
 }

--- a/tests/Utils/Html.data.phpt
+++ b/tests/Utils/Html.data.phpt
@@ -15,13 +15,21 @@ require __DIR__ . '/../bootstrap.php';
 
 test(function() {
 	$el = Html::el('div');
-	$el->data['a'] = 'one';
-	$el->data['b'] = NULL;
-	$el->data['c'] = FALSE;
-	$el->data['d'] = '';
-	$el->data['e'] = 'two';
+	$el->data = array('string' => 'string');
+	$el->data['empty'] = '';
+	$el->data['null'] = null;
+	$el->data['true'] = true;
+	$el->data['false'] = false;
+	$el->data['int'] = 42;
+	$el->data->list = array();
+	$el->data->list[] = 'one';
+	$el->{'data-list'}[] = 'two';
+	$el->data->dict = array('a' => 'A', 1 => 2);
+	$el->data->obj = new \stdClass;
+	$el->data->obj->a = 'A';
+	$el->data->obj->b = 'B';
 
-	Assert::same( '<div data-a="one" data-d="" data-e="two"></div>', (string) $el );
+	Assert::same( '<div data-string="string" data-empty="" data-true="true" data-false="false" data-int="42" data-list=\'["one","two"]\' data-dict=\'{"a":"A","1":2}\' data-obj=\'{"a":"A","b":"B"}\'></div>', (string) $el );
 });
 
 
@@ -30,13 +38,13 @@ test(function() { // direct
 	$el->{'data-x'} = 'x';
 	$el->data['x'] = 'y';
 
-	Assert::same( '<div data-x="x" data-x="y"></div>', (string) $el );
+	Assert::same( '<div data-x="y"></div>', (string) $el );
 });
 
 
 test(function() { // function
 	$el = Html::el('div');
-	$el->data('a', 'one');
+	$el->data(array('a' => 'one'));
 	$el->data('b', 'two');
 
 	Assert::same( '<div data-a="one" data-b="two"></div>', (string) $el );
@@ -47,8 +55,8 @@ test(function() {
 	$el = Html::el('div');
 	$el->data('top', NULL);
 	$el->data('active', FALSE);
-	$el->data('x', '');
-	Assert::same( '<div data-x=""></div>', (string) $el );
+	$el->addData(array('x' => ''));
+	Assert::same( '<div data-active="false" data-x=""></div>', (string) $el );
 });
 
 

--- a/tests/Utils/Html.data.phpt
+++ b/tests/Utils/Html.data.phpt
@@ -13,55 +13,49 @@ use Nette\Utils\Html,
 require __DIR__ . '/../bootstrap.php';
 
 
-test(function() {
-	$el = Html::el('div');
-	$el->data = array('string' => 'string');
-	$el->data['empty'] = '';
-	$el->data['null'] = null;
-	$el->data['true'] = true;
-	$el->data['false'] = false;
-	$el->data['int'] = 42;
-	$el->data->list = array();
-	$el->data->list[] = 'one';
-	$el->{'data-list'}[] = 'two';
-	$el->data->dict = array('a' => 'A', 1 => 2);
-	$el->data->obj = new \stdClass;
-	$el->data->obj->a = 'A';
-	$el->data->obj->b = 'B';
+test(function() { // standard usage in combination with normal attributes
+	$el = Html::el('div', array('id' => 'id', 'data-will-be' => 'overwritten'));
+	$el->data = array('x' => 'x');
+	$el->data->testAttr = 'test';
 
-	Assert::same( '<div data-string="string" data-empty="" data-true="true" data-false="false" data-int="42" data-list=\'["one","two"]\' data-dict=\'{"a":"A","1":2}\' data-obj=\'{"a":"A","b":"B"}\'></div>', (string) $el );
-});
-
-
-test(function() { // direct
-	$el = Html::el('div');
-	$el->{'data-x'} = 'x';
-	$el->data['x'] = 'y';
-
-	Assert::same( '<div data-x="y"></div>', (string) $el );
+	Assert::type( 'Nette\Utils\HtmlDataset', $el->data );
+	Assert::same( 2, count($el->data) );
+	Assert::same( '<div id="id" data-x="x" data-test-attr="test"></div>', (string) $el );
 });
 
 
 test(function() { // function
-	$el = Html::el('div');
+	$el = Html::el('div', array('data-will-be' => 'overwritten'));
 	$el->data(array('a' => 'one'));
 	$el->data('b', 'two');
+	$el->setData('c', 'three');
+	$el->addData(array('d' => 'four'));
 
-	Assert::same( '<div data-a="one" data-b="two"></div>', (string) $el );
+	Assert::type( 'Nette\Utils\HtmlDataset', $el->getData() );
+	Assert::same( 4, count($el->getData()) );
+	Assert::same( 'one', $el->getData('a') );
+	Assert::same( '<div data-a="one" data-b="two" data-c="three" data-d="four"></div>', (string) $el );
 });
 
 
-test(function() {
-	$el = Html::el('div');
-	$el->data('top', NULL);
-	$el->data('active', FALSE);
-	$el->addData(array('x' => ''));
-	Assert::same( '<div data-active="false" data-x=""></div>', (string) $el );
-});
-
-
-test(function() {
+test(function() { // simple data attribute
 	$el = Html::el('div');
 	$el->data = 'simple';
+
 	Assert::same( '<div data="simple"></div>', (string) $el );
+});
+
+
+test(function() { // backward compatibility: direct assignment using dash-separated name
+	$el = Html::el('div');
+
+	$el->{'data-test-attr'} = 'test';
+	Assert::type( 'Nette\Utils\HtmlDataset', $el->data );
+	Assert::same( 1, count($el->data) );
+	Assert::same( 'test', $el->data->testAttr );
+	Assert::true( isset($el->{'data-test-attr'}) );
+	Assert::same( 'test', $el->{'data-test-attr'} );
+
+	unset($el->{'data-test-attr'});
+	Assert::false( isset($el->{'data-test-attr'}) );
 });

--- a/tests/Utils/HtmlDataset.phpt
+++ b/tests/Utils/HtmlDataset.phpt
@@ -13,51 +13,61 @@ use Nette\Utils\HtmlDataset,
 require __DIR__ . '/../bootstrap.php';
 
 
-test(function() {
+test(function() { // standard usage
 	$d = new HtmlDataset;
-	$d['string'] = 'string';
-	$d['empty'] = '';
-	$d['null'] = null;
-	$d['true'] = true;
-	$d['false'] = false;
-	$d['int'] = 42;
-	$d->list = array(1, 2);
-	$d->dict = array('a' => 'A', 1 => 2);
-	$obj = new \stdClass;
-	$obj->a = 'A';
-	$obj->b = 'B';
-	$d->obj = $obj;
+	$d->camelCase = 'string';
+	$d->empty = '';
+	$d->null = null;
+	$d->true = true;
+	$d->false = false;
+	$d->int = 42;
+	$d->float = 4.2;
+	$d->list = array('one');
+	$d->list[] = 2;
+	$d->dict = array('a' => 'A');
+	$d->dict[] = 2;
+	$d->obj = new \stdClass;
+	$d->obj->c = 'C';
+	$d->obj->d = 2;
 
-	Assert::same( 'data-string="string" data-empty="" data-true="true" data-false="false" data-int="42" data-list="[1,2]" data-dict=\'{"a":"A","1":2}\' data-obj=\'{"a":"A","b":"B"}\'', (string) $d );
-	Assert::same( 8, count($d) );
+	Assert::false( isset($d->null) );
+	Assert::same( 'data-camel-case="string" data-empty="" data-true="true" data-false="false" data-int="42" data-float="4.2" data-list=\'["one",2]\' data-dict=\'{"a":"A","0":2}\' data-obj=\'{"c":"C","d":2}\'', (string) $d );
+	Assert::same( 9, count($d) );
 	Assert::type( '\ArrayIterator', $d->getIterator() );
+
+	$d->testAttr = 'test';
+	Assert::true( isset($d->testAttr) );
+	Assert::same( 'test', $d->testAttr );
+	unset($d->testAttr);
+	Assert::false( isset($d->testAttr) );
 });
 
 
-test(function() {
-	$d = new HtmlDataset(array('TestAttr' => false, 'testAttr' => true));
-	foreach (array('testAttr', 'test-attr', 'TestAttr', 'Test-Attr') as $name) {
-		Assert::true( isset($d->$name) );
-		Assert::true( $d->$name );
+test(function() { // backward compatibility: array access
+	$d = new HtmlDataset;
 
-		Assert::true( isset($d[$name]) );
-		Assert::true( $d[$name] );
-	}
+	$d['testAttr'] = 'test';
+	Assert::true( isset($d->testAttr) );
+	Assert::same( 'test', $d->testAttr );
+	Assert::true( isset($d['testAttr']) );
+	Assert::same( 'test', $d['testAttr'] );
 
-	Assert::false( isset($d->unknown) );
-	Assert::false( isset($d['unknown']) );
+	unset($d['testAttr']);
+	Assert::false( isset($d->testAttr) );
+	Assert::false( isset($d['testAttr']) );
 });
 
 
-test(function() {
-	$d = new HtmlDataset(array('a-b' => true, 'c-d' => true));
+test(function() { // backward compatibility: dash-separated names
+	$d = new HtmlDataset;
 
-	Assert::true( isset($d->aB) );
-	Assert::true( isset($d['cD']) );
+	$d['test-attr'] = 'test';
+	Assert::true( isset($d->testAttr) );
+	Assert::same( 'test', $d->testAttr );
+	Assert::true( isset($d['test-attr']) );
+	Assert::same( 'test', $d['test-attr'] );
 
-	unset($d->aB);
-	unset($d['cD']);
-
-	Assert::false( isset($d->aB) );
-	Assert::false( isset($d['cD']) );
+	unset($d['test-attr']);
+	Assert::false( isset($d->testAttr) );
+	Assert::false( isset($d['test-attr']) );
 });

--- a/tests/Utils/HtmlDataset.phpt
+++ b/tests/Utils/HtmlDataset.phpt
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * Test: Nette\Utils\HtmlDataset
+ *
+ * @author     Petr Morávek <petr@pada.cz>
+ */
+
+use Nette\Utils\HtmlDataset,
+	Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+test(function() {
+	$d = new HtmlDataset;
+	$d['string'] = 'string';
+	$d['empty'] = '';
+	$d['null'] = null;
+	$d['true'] = true;
+	$d['false'] = false;
+	$d['int'] = 42;
+	$d->list = array(1, 2);
+	$d->dict = array('a' => 'A', 1 => 2);
+	$obj = new \stdClass;
+	$obj->a = 'A';
+	$obj->b = 'B';
+	$d->obj = $obj;
+
+	Assert::same( 'data-string="string" data-empty="" data-true="true" data-false="false" data-int="42" data-list="[1,2]" data-dict=\'{"a":"A","1":2}\' data-obj=\'{"a":"A","b":"B"}\'', (string) $d );
+	Assert::same( 9, count($d) );
+	Assert::type( '\ArrayIterator', $d->getIterator() );
+});
+
+
+test(function() {
+	$d = new HtmlDataset(array('TestAttr' => false, 'testAttr' => true));
+	foreach (array('testAttr', 'test-attr', 'TestAttr', 'Test-Attr') as $name) {
+		Assert::true( isset($d->$name) );
+		Assert::true( $d->$name );
+
+		Assert::true( isset($d[$name]) );
+		Assert::true( $d[$name] );
+	}
+
+	Assert::false( isset($d->unknown) );
+	Assert::false( isset($d['unknown']) );
+});
+
+
+test(function() {
+	$d = new HtmlDataset(array('a-b' => true, 'c-d' => true));
+
+	Assert::true( isset($d->aB) );
+	Assert::true( isset($d['cD']) );
+
+	unset($d->aB);
+	unset($d['cD']);
+
+	Assert::false( isset($d->aB) );
+	Assert::false( isset($d['cD']) );
+});

--- a/tests/Utils/HtmlDataset.phpt
+++ b/tests/Utils/HtmlDataset.phpt
@@ -29,7 +29,7 @@ test(function() {
 	$d->obj = $obj;
 
 	Assert::same( 'data-string="string" data-empty="" data-true="true" data-false="false" data-int="42" data-list="[1,2]" data-dict=\'{"a":"A","1":2}\' data-obj=\'{"a":"A","b":"B"}\'', (string) $d );
-	Assert::same( 9, count($d) );
+	Assert::same( 8, count($d) );
 	Assert::type( '\ArrayIterator', $d->getIterator() );
 });
 


### PR DESCRIPTION
This PR (inspired by nette/nette#1399) improves handling of data attributes in `Html` objects.
- Non-scalar values are encoded using JSON in the output.
- Camel case data attribute names are automatically converted to dash separated names in the output.
- No more confusion between `$el->{'data-x'}`, `$el->data['x']` etc., both now point to the same place.
- Added getter for data attributes `$el->getData('x')`.
- The preferred way of manipulating data attributes is via properties, e.g.:

``` php
$el->data->camelCase = array();
$el->data->camelCase[] = 'item';
```

The important thing is that this change is mostly backward compatible, but there are some corner cases that won't work any more:
- Using combination of simple data attribute and named data attributes.
- The output of `$el->data['camleCase'] = 'whatever';` has changed, so if you rely on the old behavior (which you definitely should not!), you're out of luck.
- The encoding of `TRUE` and `FALSE` **for custom data attributes** has changed - the motivation for this is consistency with e.g. jQuery, so if you retrieve data using `$("#elem").data()`, you get the expected result.

There are couple of things that probably need some polishing. I'm wondering about two things (that could lead to overall simplification of the code):
1. Is the simple `data="whatever"` attribute really useful? I would gladly throw it away, but that's BC break.
2. Should the new way of manipulating data attributes be enforced more aggressively (trigger deprecation warnings)? The old way could be completely removed in the future.
