### PR TITLE
DateTime: createFromFormat() returns Nette\Utils\DateTime instance

### DIFF
--- a/src/Utils/DateTime.php
+++ b/src/Utils/DateTime.php
@@ -86,4 +86,27 @@ class DateTime extends \DateTime
 		return is_float($tmp = $ts * 1) ? $ts : $tmp;
 	}
 
+
+	/**
+	 * Returns new DateTime object formatted according to the specified format.
+	 * @param string The format the $time parameter should be in
+	 * @param string String representing the time
+	 * @param string|\DateTimeZone desired timezone (default timezone is used if NULL is passed)
+	 * @return DateTime
+	 */
+	public static function createFromFormat($format, $time, $timezone = NULL)
+	{
+		if ($timezone === NULL) {
+			$timezone = new \DateTimeZone(date_default_timezone_get());
+
+		} elseif (is_string($timezone)) {
+			$timezone = new \DateTimeZone($timezone);
+
+		} elseif (!$timezone instanceof \DateTimeZone) {
+			throw new Nette\InvalidArgumentException('Invalid timezone given');
+		}
+
+		return static::from(parent::createFromFormat($format, $time, $timezone));
+	}
+
 }

--- a/tests/Utils/DateTime.createFromFormat.phpt
+++ b/tests/Utils/DateTime.createFromFormat.phpt
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Test: Nette\DateTime::createFromFormat().
+ *
+ * @author     Radek Ježdík
+ */
+
+use Tester\Assert,
+	Nette\Utils\DateTime;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+date_default_timezone_set('Europe/Prague');
+
+Assert::type( 'Nette\Utils\DateTime', DateTime::createFromFormat('Y-m-d H:i:s', '2050-08-13 11:40:00') );
+Assert::type( 'Nette\Utils\DateTime', DateTime::createFromFormat('Y-m-d H:i:s', '2050-08-13 11:40:00', new DateTimeZone('Europe/Prague')) );
+
+Assert::same( '2050-08-13 11:40:00', (string) DateTime::createFromFormat('Y-m-d H:i:s', '2050-08-13 11:40:00') );
+
+Assert::same( 'Europe/Prague', DateTime::createFromFormat('Y', '2050')->getTimezone()->getName() );
+Assert::same( 'Europe/Bratislava', DateTime::createFromFormat('Y', '2050', 'Europe/Bratislava')->getTimezone()->getName() );
+
+Assert::error(function(){
+	DateTime::createFromFormat('Y-m-d H:i:s', '2050-08-13 11:40:00', 5);
+}, 'Nette\InvalidArgumentException', 'Invalid timezone given' );

--- a/tests/Utils/DateTime.from.phpt
+++ b/tests/Utils/DateTime.from.phpt
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Test: Nette\Utils\DateTime test.
+ * Test: Nette\Utils\DateTime::from().
  *
  * @author     David Grudl
  */


### PR DESCRIPTION
Static factory method `createFromFormat()` now returns `Nette\Utils\DateTime` instance instead of PHP's `\DateTime`.

This fixes somewhat unexpected behaviour when calling factory method on a `Nette\Utils\DateTime` class and receiving an instance of different class.

Closes nette/nette#1258.

Note: I used `call_user_func_array()` because the third parameter is optional and cannot be `NULL` for the parent method. I didn't want to use an `if` condition just for this (but if it is found ugly I will update it).
