### PR TITLE
Random: PHP bug 52523 has been fixed in 5.3.7

### DIFF
--- a/src/Utils/Random.php
+++ b/src/Utils/Random.php
@@ -36,7 +36,7 @@ class Random
 		) {
 			$rand3 = openssl_random_pseudo_bytes($length);
 		}
-		if (empty($rand3) && function_exists('mcrypt_create_iv') && (PHP_VERSION_ID !== 50303 || !defined('PHP_WINDOWS_VERSION_BUILD'))) { // PHP bug #52523
+		if (empty($rand3) && function_exists('mcrypt_create_iv') && (PHP_VERSION_ID >= 50307 || !defined('PHP_WINDOWS_VERSION_BUILD'))) { // PHP bug #52523
 			$rand3 = mcrypt_create_iv($length, MCRYPT_DEV_URANDOM);
 		}
 		if (empty($rand3) && @is_readable('/dev/urandom')) {


### PR DESCRIPTION
I hit this issue on `Win7 PHP 5.3.6`. There is a fix (https://github.com/nette/utils/commit/f9c5cb9017c8615fcd88cf7e9d0aeba52a76c69c) for [PHP bug 52523](https://bugs.php.net/bug.php?id=52523) but for PHP 5.3.3 only.

I found it has been fixed in 5.3.7. Search for `Change E_ERROR to E_WARNING in mcrypt_create_iv` at http://php.net/ChangeLog-5.php.
