### PR TITLE
Iterators\Filter: count() counts only fitlered items

### DIFF
--- a/src/Iterators/Filter.php
+++ b/src/Iterators/Filter.php
@@ -33,4 +33,13 @@ class Filter extends \FilterIterator
 		return call_user_func($this->callback, $this->current(), $this->key(), $this);
 	}
 
+
+	public function __call($name, $arguments) {
+		if (strtolower($name) === 'count') {
+			return iterator_count($this);
+		} else {
+			return parent::__call($name, $arguments);
+		}
+	}
+
 }

--- a/tests/Iterators/Filter.count.phpt
+++ b/tests/Iterators/Filter.count.phpt
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Test: Nette\Iterators\Filter count()
+ */
+
+use Nette\Iterators,
+	Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+test(function() {
+	$arr = array('Zero', 'One', 'Two', 'Three', 'Four');
+	$isKeyEven = function($value, $key) {
+		return $key % 2 === 0;
+	};
+	$isKeyOdd = function($value, $key) {
+		return $key % 2 !== 0;
+	};
+	$iterator = new \ArrayIterator($arr);
+	$evenIterator = new Iterators\Filter( $iterator, $isKeyEven);
+	$oddIterator = new Iterators\Filter( $iterator, $isKeyOdd);
+	Assert::same( 3, $evenIterator->count() );
+	Assert::same( 2, $oddIterator->count() );
+});
+


### PR DESCRIPTION
Fixes behaviour of count() method - now it counts only filtered items, not all items
