### PR TITLE
Improve transliteration support in Strings::toAscii

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
 	},
 	"suggest": {
 		"ext-iconv": "to use Strings::webalize() and toAscii()",
+		"ext-intl": "for script transliteration in Strings::webalize() and toAscii()",
 		"ext-mbstring": "to use Strings::lower() etc...",
 		"ext-gd": "to use Image"
 	},

--- a/src/Utils/Strings.php
+++ b/src/Utils/Strings.php
@@ -174,6 +174,9 @@ class Strings
 		$s = str_replace(array("\xE2\x80\x9E", "\xE2\x80\x9C", "\xE2\x80\x9D", "\xE2\x80\x9A",
 			"\xE2\x80\x98", "\xE2\x80\x99", "\xC2\xBB", "\xC2\xAB"),
 			array("\x03", "\x03", "\x03", "\x02", "\x02", "\x02", ">>", "<<"), $s);
+		if (class_exists('Transliterator') && $transliterator = \Transliterator::create('Any-Latin; Latin-ASCII')) {
+			$s = $transliterator->transliterate($s);
+		}
 		if (ICONV_IMPL === 'glibc') {
 			$s = @iconv('UTF-8', 'WINDOWS-1250//TRANSLIT', $s); // intentionally @
 			$s = strtr($s, "\xa5\xa3\xbc\x8c\xa7\x8a\xaa\x8d\x8f\x8e\xaf\xb9\xb3\xbe\x9c\x9a\xba\x9d\x9f\x9e"

--- a/tests/Utils/Strings.toAscii().phpt
+++ b/tests/Utils/Strings.toAscii().phpt
@@ -15,3 +15,8 @@ Assert::same( 'ZLUTOUCKY KUN oooo--', Strings::toAscii("\xc5\xbdLU\xc5\xa4OU\xc4
 Assert::same( 'Zlutoucky kun', Strings::toAscii("Z\xCC\x8Clut\xCC\x8Couc\xCC\x8Cky\xCC\x81 ku\xCC\x8An\xCC\x8C") ); // Žluťoučký kůň with combining characters
 Assert::same( 'Z `\'"^~', Strings::toAscii("\xc5\xbd `'\"^~") );
 Assert::same( '"""\'\'\'>><<', Strings::toAscii("\xE2\x80\x9E\xE2\x80\x9C\xE2\x80\x9D\xE2\x80\x9A\xE2\x80\x98\xE2\x80\x99\xC2\xBB\xC2\xAB") ); // „“”‚‘’»«
+
+if (class_exists('Transliterator') && \Transliterator::create('Any-Latin; Latin-ASCII')) {
+	Assert::same( 'Athena->Moskva', Strings::toAscii("\xCE\x91\xCE\xB8\xCE\xAE\xCE\xBD\xCE\xB1\xE2\x86\x92\xD0\x9C\xD0\xBE\xD1\x81\xD0\xBA\xD0\xB2\xD0\xB0") ); // Αθήνα→Москва
+}
+

--- a/tests/Utils/Strings.webalize().phpt
+++ b/tests/Utils/Strings.webalize().phpt
@@ -13,4 +13,4 @@ require __DIR__ . '/../bootstrap.php';
 
 Assert::same( 'zlutoucky-kun-oooo', Strings::webalize("&\xc5\xbdLU\xc5\xa4OU\xc4\x8cK\xc3\x9d K\xc5\xae\xc5\x87 \xc3\xb6\xc5\x91\xc3\xb4o!") ); // &ŽLUŤOUČKÝ KŮŇ öőôo!
 Assert::same( 'ZLUTOUCKY-KUN-oooo', Strings::webalize("&\xc5\xbdLU\xc5\xa4OU\xc4\x8cK\xc3\x9d K\xc5\xae\xc5\x87 \xc3\xb6\xc5\x91\xc3\xb4o!", NULL, FALSE) ); // &ŽLUŤOUČKÝ KŮŇ öőôo!
-Assert::same( '1-4-!',  Strings::webalize("\xc2\xBC!", '!') );
+Assert::same( '1-4-!',  Strings::webalize("\xc2\xBC !", '!') );


### PR DESCRIPTION
There are some cases where the ICONV and ICU transliteration will be different. One of them is in the webalize test - ICONV: `"¼"` -> `"1/4 "`, ICU: `"¼"` -> `"1/4"`.

Transliterator is available since PHP 5.4 with intl extension enabled
