### PR TITLE
Nette\Object::getReflection() return value fixed

### DIFF
--- a/src/Utils/Object.php
+++ b/src/Utils/Object.php
@@ -56,7 +56,7 @@ abstract class Object
 
 	/**
 	 * Access to reflection.
-	 * @return ReflectionClass
+	 * @return Nette\Reflection\ClassType|\ReflectionClass
 	 */
 	public static function getReflection()
 	{


### PR DESCRIPTION
`Nette\ReflectionClass` doesn't exist.
This makes IDE's suggestion work properly.
