### PR TITLE
Utils\Html: attribute public accessor methods added

### DIFF
--- a/src/Utils/Html.php
+++ b/src/Utils/Html.php
@@ -129,6 +129,74 @@ class Html implements \ArrayAccess, \Countable, \IteratorAggregate, IHtmlString
 
 
 	/**
+	 * Adds one element's attribute.
+	 * @param  string    HTML attribute name
+	 * @param  mixed     HTML attribute value
+	 * @param  mixed     HTML attribute value's data
+	 * @return self
+	 */
+	public function appendAttribute($name, $value, $data = TRUE)
+	{
+		if (is_array($value)) {
+			// allow append & replace existing values with new ones
+			$prev = [];
+			if (isset($this->attrs[$name])) {
+				$prev = (array) $this->attrs[$name];
+			}
+
+			$this->attrs[$name] = array_merge($prev, $value);
+
+		} elseif ((string) $value === '') {
+			$tmp = & $this->attrs[$name]; // appending empty value? -> ignore, but ensure it exists
+
+		} elseif (!isset($this->attrs[$name]) || is_array($this->attrs[$name])) { // needs array
+			$this->attrs[$name][$value] = $data;
+
+		} else {
+			$this->attrs[$name] = [$this->attrs[$name] => TRUE, $value => $data];
+		}
+
+		return $this;
+	}
+
+
+	/**
+	 * Sets one element's attribute.
+	 * @param  string    HTML attribute name
+	 * @param  mixed     HTML attribute value
+	 * @return self
+	 */
+	public function setAttribute($name, $value)
+	{
+		$this->attrs[$name] = $value;
+		return $this;
+	}
+
+
+	/**
+	 * Gets one element's attribute.
+	 * @param  string    HTML attribute name
+	 * @return mixed     HTML attribute value
+	 */
+	public function getAttribute($name)
+	{
+		return isset($this->attrs[$name]) ? $this->attrs[$name] : NULL;
+	}
+
+
+	/**
+	 * Unsets one element's attribute.
+	 * @param  string    HTML attribute name
+	 * @return self
+	 */
+	public function removeAttribute($name)
+	{
+		unset($this->attrs[$name]);
+		return $this;
+	}
+
+
+	/**
 	 * Overloaded setter for element's attribute.
 	 * @param  string    HTML attribute name
 	 * @param  mixed     HTML attribute value
@@ -186,7 +254,7 @@ class Html implements \ArrayAccess, \Countable, \IteratorAggregate, IHtmlString
 			$m = substr($m, 3);
 			$m[0] = $m[0] | "\x20";
 			if ($p === 'get') {
-				return isset($this->attrs[$m]) ? $this->attrs[$m] : NULL;
+				return $this->getAttribute($m);
 
 			} elseif ($p === 'add') {
 				$args[] = TRUE;
@@ -196,16 +264,10 @@ class Html implements \ArrayAccess, \Countable, \IteratorAggregate, IHtmlString
 		if (count($args) === 0) { // invalid
 
 		} elseif (count($args) === 1) { // set
-			$this->attrs[$m] = $args[0];
+			$this->setAttribute($m, $args[0]);
 
-		} elseif ((string) $args[0] === '') {
-			$tmp = & $this->attrs[$m]; // appending empty value? -> ignore, but ensure it exists
-
-		} elseif (!isset($this->attrs[$m]) || is_array($this->attrs[$m])) { // needs array
-			$this->attrs[$m][$args[0]] = $args[1];
-
-		} else {
-			$this->attrs[$m] = [$this->attrs[$m], $args[0] => $args[1]];
+		} else { // add
+			$this->appendAttribute($m, $args[0], $args[1]);
 		}
 
 		return $this;

--- a/tests/Utils/Html.basic.phpt
+++ b/tests/Utils/Html.basic.phpt
@@ -22,10 +22,36 @@ test(function () {
 
 test(function () {
 	Html::$xhtml = TRUE;
+	$el = Html::el('img')->setAttribute('src', 'image.gif')->setAttribute('alt', '');
+	Assert::same('<img src="image.gif" alt="" />', (string) $el);
+	Assert::same('<img src="image.gif" alt="" />', $el->startTag());
+	Assert::same('', $el->endTag());
+});
+
+
+test(function () {
+	Html::$xhtml = TRUE;
 	$el = Html::el('img')->accesskey(0, TRUE)->alt('alt', FALSE);
 	Assert::same('<img accesskey="0" />', (string) $el);
 	Assert::same('<img accesskey="0 1" />', (string) $el->accesskey(1, TRUE));
+	Assert::same('<img accesskey="0" />', (string) $el->accesskey(1, FALSE));
+	Assert::same('<img accesskey="0" />', (string) $el->accesskey(0, TRUE));
 	Assert::same('<img accesskey="0" />', (string) $el->accesskey(0));
+
+	unset($el->accesskey);
+	Assert::same('<img />', (string) $el);
+});
+
+
+test(function () {
+	Html::$xhtml = TRUE;
+	$el = Html::el('img')->appendAttribute('accesskey', 0)->setAttribute('alt', FALSE);
+	Assert::same('<img accesskey="0" />', (string) $el);
+	Assert::same('<img accesskey="0 1" />', (string) $el->appendAttribute('accesskey', 1));
+	Assert::same('<img accesskey="0" />', (string) $el->appendAttribute('accesskey', 1, FALSE));
+	Assert::same('<img accesskey="0" />', (string) $el->appendAttribute('accesskey', 0));
+	Assert::same('<img accesskey="0" />', (string) $el->setAttribute('accesskey', 0));
+	Assert::same('<img />', (string) $el->removeAttribute('accesskey'));
 });
 
 
@@ -46,7 +72,9 @@ test(function () {
 	Assert::same('<img src="image.gif" alt="alt2">', (string) $el);
 	Assert::same('image.gif', $el->getSrc());
 	Assert::null($el->getTitle());
+	Assert::null($el->getAttribute('title'));
 	Assert::same('alt2', $el->getAlt());
+	Assert::same('alt2', $el->getAttribute('alt'));
 
 	$el->addAlt('alt3');
 	Assert::same('<img src="image.gif" alt="alt2 alt3">', (string) $el);
@@ -109,4 +137,15 @@ test(function () { // href with query
 test(function () { // isset
 	Assert::false(isset(Html::el('a')->id));
 	Assert::true(isset(Html::el('a')->id('')->id));
+
+	Html::el('a')->id = NULL;
+	Assert::false(isset(Html::el('a')->id));
+});
+
+
+test(function () { // isset
+	Assert::true(isset(Html::el('a')->setAttribute('id', '')->id));
+	Assert::false(isset(Html::el('a')->removeAttribute('id')->id));
+	Assert::true(isset(Html::el('a')->setAttribute('id', '')->id));
+	Assert::false(isset(Html::el('a')->setAttribute('id', NULL)->id));
 });

--- a/tests/Utils/Html.data.phpt
+++ b/tests/Utils/Html.data.phpt
@@ -58,6 +58,18 @@ test(function () { // special values
 });
 
 
+test(function () { // setter
+	$el = Html::el('div');
+	$el->setAttribute('data-x', 'x');
+	$el->setAttribute('data-list', [1,2,3]);
+	$el->setAttribute('data-arr', ['a' => 1]);
+	$el->setAttribute('top', NULL);
+	$el->setAttribute('active', FALSE);
+
+	Assert::same('<div data-x="x" data-list="[1,2,3]" data-arr=\'{"a":1}\'></div>', (string) $el);
+});
+
+
 test(function () {
 	$el = Html::el('div');
 	$el->data = 'simple';
@@ -65,4 +77,7 @@ test(function () {
 
 	$el->data('simple2');
 	Assert::same('<div data="simple2"></div>', (string) $el);
+
+	$el->setAttribute('data', 'simple3');
+	Assert::same('<div data="simple3"></div>', (string) $el);
 });

--- a/tests/Utils/Html.style.phpt
+++ b/tests/Utils/Html.style.phpt
@@ -30,17 +30,51 @@ test(function () {
 });
 
 
+test(function () {
+	$el = Html::el('div');
+	$el->appendAttribute('style', 'text-align:right');
+	$el->appendAttribute('style', NULL);
+	$el->appendAttribute('style', 'background-color: blue');
+	$el->appendAttribute('class', 'one');
+	$el->appendAttribute('class', NULL);
+	$el->appendAttribute('class', 'two');
+
+	Assert::same('<div style="text-align:right;background-color: blue" class="one two"></div>', (string) $el);
+
+
+	$el->setAttribute('style', NULL);
+	$el->appendAttribute('style', 'text-align', 'left');
+	$el->appendAttribute('style', 'background-color', 'green');
+	Assert::same('<div style="text-align:left;background-color:green" class="one two"></div>', (string) $el);
+
+
+	$el->setAttribute('style', [
+		'text-align' => 'right',
+		'background-color' => 'red',
+	]);
+	Assert::same('<div style="text-align:right;background-color:red" class="one two"></div>', (string) $el);
+
+
+	$el->appendAttribute('style', [
+		'text-align' => 'center',
+		'color' => 'orange',
+	]);
+	Assert::same('<div style="text-align:center;background-color:red;color:orange" class="one two"></div>', (string) $el);
+});
+
+
 test(function () { // append
 	$el = Html::el('div');
 	$el->style('color', 'white');
 	$el->style('background-color', 'blue');
+	$el->appendAttribute('style', 'text-align', 'left');
 
 	$el->class = 'one';
 	$el->class('', TRUE);
 	$el->class('two', TRUE);
 
 	$el->id('my', TRUE);
-	Assert::same('<div style="color:white;background-color:blue" class="one two" id="my"></div>', (string) $el);
+	Assert::same('<div style="color:white;background-color:blue;text-align:left" class="one two" id="my"></div>', (string) $el);
 });
 
 
@@ -49,7 +83,8 @@ test(function () { // append II
 	$el->style[] = 'text-align:right';
 	$el->style('', TRUE);
 	$el->style('background-color: blue', TRUE);
-	Assert::same('<div style="text-align:right;background-color: blue"></div>', (string) $el);
+	$el->appendAttribute('style', 'color: orange', TRUE);
+	Assert::same('<div style="text-align:right;background-color: blue;color: orange"></div>', (string) $el);
 });
 
 
@@ -57,10 +92,12 @@ test(function () { // append III
 	$el = Html::el('div');
 	$el->class('top', TRUE);
 	$el->class('active', TRUE);
-	Assert::same('<div class="top active"></div>', (string) $el);
+	$el->appendAttribute('class', 'pull-right', TRUE);
+	Assert::same('<div class="top active pull-right"></div>', (string) $el);
 
 
 	$el->class('top', NULL);
 	$el->class('active', FALSE);
+	$el->appendAttribute('class', 'pull-right', FALSE);
 	Assert::same('<div></div>', (string) $el);
 });


### PR DESCRIPTION
Closes #37 

New methods added & `::__call` refactored.
Full back-compatibility (see tests), new tests added.