### PR TITLE
ObjectMixin: added support for areSomething (similar to isSomething)

### DIFF
--- a/src/Utils/ObjectMixin.php
+++ b/src/Utils/ObjectMixin.php
@@ -128,7 +128,7 @@ class ObjectMixin
 		if ($name === '') {
 			throw new MemberAccessException("Cannot read a class '$class' property without name.");
 
-		} elseif (isset($methods[$m = 'get' . $uname]) || isset($methods[$m = 'is' . $uname])) { // property getter
+		} elseif (isset($methods[$m = 'get' . $uname]) || isset($methods[$m = 'is' . $uname]) || isset($methods[$m = 'are' . $uname])) { // property getter
 			if ($methods[$m] === 0) {
 				$rm = new \ReflectionMethod($class, $m);
 				$methods[$m] = $rm->returnsReference();

--- a/tests/Utils/Object.property.phpt
+++ b/tests/Utils/Object.property.phpt
@@ -43,6 +43,16 @@ class TestClass extends Nette\Object
 		$this->bar = $value;
 	}
 
+	public function isAwesome()
+	{
+		return $this->foo === 'awesome';
+	}
+
+	public function areCool()
+	{
+		return $this->bar === 'cool';
+	}
+
 	public function gets() // or setupXyz, settle...
 	{
 		echo __METHOD__;
@@ -97,3 +107,9 @@ Assert::same( 'World', $obj->bar );
 Assert::exception(function() use ($obj) {
 	$val = $obj->bazz;
 }, 'Nette\MemberAccessException', 'Cannot read a write-only property TestClass::$bazz.');
+
+
+// isFoo && areFoo
+$obj = new TestClass('awesome', 'notCool');
+Assert::true( $obj->awesome );
+Assert::false( $obj->cool );


### PR DESCRIPTION
I found this in some project I was working on. I needed to use `Accommodation::areDogsAllowed()` with magic getter, and `Accommodation::isDogsAllowed()` contains grammar mistake.