### PR TITLE
Strings::normalize should remove C1 control codes as well

### DIFF
--- a/src/Utils/Strings.php
+++ b/src/Utils/Strings.php
@@ -139,7 +139,7 @@ class Strings
 
 	/**
 	 * Removes special controls characters and normalizes line endings and spaces.
-	 * @param  string  UTF-8 encoding or 8-bit
+	 * @param  string  UTF-8 encoding
 	 * @return string
 	 */
 	public static function normalize($s)
@@ -147,7 +147,7 @@ class Strings
 		$s = self::normalizeNewLines($s);
 
 		// remove control characters; leave \t + \n
-		$s = preg_replace('#[\x00-\x08\x0B-\x1F\x7F]+#', '', $s);
+		$s = preg_replace('#[\x00-\x08\x0B-\x1F\x7F-\x9F]+#u', '', $s);
 
 		// right trim
 		$s = preg_replace('#[\t ]+$#m', '', $s);

--- a/tests/Utils/Strings.normalize().phpt
+++ b/tests/Utils/Strings.normalize().phpt
@@ -16,4 +16,8 @@ Assert::same( "Hello\n  World",  Strings::normalize("\r\nHello  \r  World \n\n")
 Assert::same( "Hello  World",  Strings::normalize("Hello \x00 World") );
 Assert::same( "Hello  World",  Strings::normalize("Hello \x0B World") );
 Assert::same( "Hello  World",  Strings::normalize("Hello \x1F World") );
+Assert::same( "Hello \x7E World",  Strings::normalize("Hello \x7E World") );
 Assert::same( "Hello  World",  Strings::normalize("Hello \x7F World") );
+Assert::same( "Hello  World",  Strings::normalize("Hello \xC2\x80 World") );
+Assert::same( "Hello  World",  Strings::normalize("Hello \xC2\x9F World") );
+Assert::same( "Hello \xC2\xA0 World",  Strings::normalize("Hello \xC2\xA0 World") );


### PR DESCRIPTION
Strings::normalize should remove C1 control codes (U+0080 to U+009F) as well. This would however be a BC break because currently Strings::normalize works for non-utf8 strings as well.

This would also make Strings::normalize behavior closer to what Http\RequestFactory::NONCHARS is used for.

http://en.wikipedia.org/wiki/Unicode_control_characters
http://en.wikipedia.org/wiki/C0_and_C1_control_codes
