### PR TITLE
Arrays.php: Remove unneccessary is_array() call

### DIFF
--- a/src/Utils/Arrays.php
+++ b/src/Utils/Arrays.php
@@ -38,7 +38,7 @@ class Arrays
 	public static function get(array $arr, $key, $default = NULL)
 	{
 		foreach (is_array($key) ? $key : array($key) as $k) {
-			if (is_array($arr) && array_key_exists($k, $arr)) {
+			if (array_key_exists($k, $arr)) {
 				$arr = $arr[$k];
 			} else {
 				if (func_num_args() < 3) {


### PR DESCRIPTION
We don't need to check if argument for `$arr` parameter `is_array()`, because there's a type hint for the formal parameter above in method definition.