### PR TITLE
Workaround (hopefully temporary) for changed signature of DateTime::createFromFormat in PHP7

### DIFF
--- a/src/Utils/DateTime.php
+++ b/src/Utils/DateTime.php
@@ -10,6 +10,9 @@ namespace Nette\Utils;
 use Nette;
 
 
+// workaround for changed signature of createFromFormat in PHP 7
+@call_user_func(function() {
+
 /**
  * DateTime.
  *
@@ -125,3 +128,5 @@ class DateTime extends \DateTime
 	}
 
 }
+
+});


### PR DESCRIPTION
Changed signature of DateTime::createFromFormat in PHP7 makes a lot of Nette tests fail.

We may
A) ignore it for now
B) workaround it
C) remove the method entirely