### PR TITLE
Json: add fix for Json::decode() collision attack

### DIFF
--- a/src/Utils/Json.php
+++ b/src/Utils/Json.php
@@ -98,6 +98,65 @@ class Json
 		return $value;
 	}
 
+
+	/**
+	 * Safely decodes a JSON string.
+	 * @param  string
+	 * @param  int  accepts Json::FORCE_ARRAY
+	 * @param  float
+	 * @return mixed
+	 */
+	public static function decodeSafe($json, $options = 0, $timeLimit = 2.0)
+	{
+		$timeLimit += microtime(true);
+
+		$json = preg_replace_callback('#"(?:\\\\.|[^"\\\\])*"#', function($m) use (&$salt) {
+			if ($salt === null || !mt_rand(0, 100)) {
+				$salt = Nette\Utils\Random::generate(3, 'a-zA-Z');
+			}
+			return '"' . $salt . substr($m[0], 1);
+		}, $json);
+
+		$value = static::decode($json, $options);
+
+		$queue = array(& $value);
+		while (list($key, $val) = each($queue)) {
+			if (is_string($val)) {
+				if (ctype_alpha($val[0])) {
+					$queue[$key] = substr($val, 3);
+				}
+			} elseif (is_array($val)) {
+				$iterations = 0;
+				$cleaned = array();
+				foreach ($val as $k => $v) {
+					$k = substr($k, 3);
+					$cleaned[$k] = $v;
+					$queue[] = & $cleaned[$k];
+					if (++$iterations % 1000 === 0 && microtime(true) > $timeLimit) {
+						throw new JsonException('Time limit exceeded');
+					}
+				}
+				$queue[$key] = $cleaned;
+			} elseif (is_object($val)) {
+				$iterations = 0;
+				$cleaned = new \stdClass;
+				foreach ((array) $val as $k => $v) {
+					$k = substr($k, 3);
+					if (substr($k, 0) === "\0") {
+						throw new JsonException(static::$messages[JSON_ERROR_CTRL_CHAR]);
+					}
+					$cleaned->$k = $v;
+					$queue[] = & $cleaned->$k;
+					if (++$iterations % 1000 === 0 && microtime(true) > $timeLimit) {
+						throw new JsonException('Time limit exceeded');
+					}
+				}
+				$queue[$key] = $cleaned;
+			}
+		}
+		return $value;
+	}
+
 }
 
 

--- a/tests/Utils/Json.decodeSafe().collisionAttack.phpt
+++ b/tests/Utils/Json.decodeSafe().collisionAttack.phpt
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Test: Nette\Utils\Json::decodeSafe() collision attack.
+ */
+
+use Nette\Utils\Json,
+	Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$factor = (1 << 20);
+
+$s = '{';
+for ($i = 0; $i < 100000; $i++) {
+	if ($i !== 0) {
+		$s .= ',';
+	}
+	$s .= '"' . ($i * $factor) . '":0';
+}
+$s .= '}';
+
+
+$elapsedTime = -microtime(true);
+
+Assert::exception(function() use ($s) {
+	Json::decodeSafe($s, Json::FORCE_ARRAY);
+}, 'Nette\Utils\JsonException', 'Time limit exceeded');
+
+$elapsedTime += microtime(true);
+
+Assert::true($elapsedTime < 3.0);

--- a/tests/Utils/Json.decodeSafe().phpt
+++ b/tests/Utils/Json.decodeSafe().phpt
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * Test: Nette\Utils\Json::decodeSafe()
+ */
+
+use Nette\Utils\Json,
+	Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+Assert::same( "ok", Json::decodeSafe('"ok"') );
+Assert::null( Json::decodeSafe('') );
+Assert::null( Json::decodeSafe('null') );
+Assert::null( Json::decodeSafe('NULL') );
+
+
+Assert::equal( (object) array('a' => 1), Json::decodeSafe('{"a":1}') );
+Assert::same( array('a' => 1), Json::decodeSafe('{"a":1}', Json::FORCE_ARRAY) );
+
+
+Assert::exception(function() {
+	Json::decodeSafe('{');
+}, 'Nette\Utils\JsonException', 'Syntax error, malformed JSON');
+
+
+Assert::exception(function() {
+	Json::decodeSafe('{}}');
+}, 'Nette\Utils\JsonException', 'Syntax error, malformed JSON');
+
+
+Assert::exception(function() {
+	Json::decodeSafe("\x00");
+}, 'Nette\Utils\JsonException', defined('JSON_C_VERSION') ? 'Syntax error, malformed JSON' : 'Unexpected control character found');
+
+
+Assert::exception(function() {
+	Json::decodeSafe('{"\u0000": 1}');
+}, 'Nette\Utils\JsonException', 'Unexpected control character found');
+
+
+Assert::same( array("\x00" => 1), Json::decodeSafe('{"\u0000": 1}', Json::FORCE_ARRAY) );
+Assert::equal( (object) array('a' => "\x00"), Json::decodeSafe('{"a": "\u0000"}') );
+Assert::equal( (object) array("\"\x00" => 1), Json::decodeSafe('{"\"\u0000": 1}') );
+
+
+Assert::exception(function() {
+	Json::decodeSafe("\"\xC1\xBF\"");
+}, 'Nette\Utils\JsonException', 'Invalid UTF-8 sequence');
+
+
+// default JSON_BIGINT_AS_STRING
+if (PHP_VERSION_ID >= 50400) {
+	if (defined('JSON_C_VERSION')) {
+		if (PHP_INT_SIZE > 4) {
+			# 64-bit
+			Assert::same( array(9223372036854775807), Json::decodeSafe('[12345678901234567890]') );   # trimmed to max 64-bit integer
+		} else {
+			# 32-bit
+			Assert::same( array('9223372036854775807'), Json::decodeSafe('[12345678901234567890]') );  # trimmed to max 64-bit integer
+		}
+
+	} else {
+		Assert::same( array('12345678901234567890'), Json::decodeSafe('[12345678901234567890]') );
+	}
+}


### PR DESCRIPTION
If you are using Json::decode() in your application on a user input, it is prone to denial-of-service (DoS) attacks. The worst case time complexity of json_decode() is O(n^2), where n is the number of elements in the object. The test case in this pull request creates a 1,6 megabyte JSON string that takes about 1 minute to decode.

This could be fixed using randomization. If the JSON string is longer than ~50000 characters, we can prepend all string literals with ~3 random characters using a regexp. Then we can iterate over the returned arrays, objects and strings and remove the prepended characters from them. We can measure time from the beginning of the call of the Json::decode() method every ~1000 iterations. If it is longer than ~1 second, we can throw an exception.

Do you think it is a good idea?