### PR TITLE
Fix Arrays::associate if $rowOrig is Traversable

### DIFF
--- a/src/Utils/Arrays.php
+++ b/src/Utils/Arrays.php
@@ -188,7 +188,7 @@ class Arrays
 		$res = $parts[0] === '->' ? new \stdClass : array();
 
 		foreach ($arr as $rowOrig) {
-			$row = (array) $rowOrig;
+			$row = $rowOrig instanceof \Traversable ? iterator_to_array($rowOrig) : (array) $rowOrig;
 			$x = & $res;
 
 			for ($i = 0; $i < count($parts); $i++) {


### PR DESCRIPTION
Arrays::associate fails if $rowOrig is not array or instance of stdClass.