### PR TITLE
DateTime @return anotation changed to "static"

### DIFF
--- a/src/Utils/DateTime.php
+++ b/src/Utils/DateTime.php
@@ -42,7 +42,7 @@ class DateTime extends \DateTime implements \JsonSerializable
 	/**
 	 * DateTime object factory.
 	 * @param  string|int|\DateTime
-	 * @return DateTime
+	 * @return static
 	 */
 	public static function from($time)
 	{
@@ -108,7 +108,7 @@ class DateTime extends \DateTime implements \JsonSerializable
 	 * @param string The format the $time parameter should be in
 	 * @param string String representing the time
 	 * @param string|\DateTimeZone desired timezone (default timezone is used if NULL is passed)
-	 * @return DateTime|FALSE
+	 * @return static|FALSE
 	 */
 	public static function createFromFormat($format, $time, $timezone = NULL)
 	{


### PR DESCRIPTION
- feature
- issues
- documentation - not needed
- BC break - no

**Why this?** 
When I inherit `Nette\DateTime` and add `xyz` method to this child-class, and then I create new instace like:

```php
$dateTime = MyDateTime::from('2015-12-24 12:00:00');
$dateTime->xyz();  // <-- here, IDE assume its Nete\DateTime 
                   // where no xyz method has been declared.
```

See: http://www.phpdoc.org/docs/latest/guides/types.html