### PR TITLE
Random: use random_bytes() on PHP 7

### DIFF
--- a/src/Utils/Random.php
+++ b/src/Utils/Random.php
@@ -26,6 +26,10 @@ class Random
 	 */
 	public static function generate($length = 10, $charlist = '0-9a-z')
 	{
+		if ($length === 0) {
+			return ''; // mcrypt_create_iv does not support zero length
+		}
+
 		$charlist = str_shuffle(preg_replace_callback('#.-.#', function($m) {
 			return implode('', range($m[0][0], $m[0][2]));
 		}, $charlist));

--- a/src/Utils/Random.php
+++ b/src/Utils/Random.php
@@ -27,7 +27,7 @@ class Random
 	public static function generate($length = 10, $charlist = '0-9a-z')
 	{
 		if ($length === 0) {
-			return ''; // mcrypt_create_iv does not support zero length
+			return ''; // random_bytes and mcrypt_create_iv do not support zero length
 		}
 
 		$charlist = str_shuffle(preg_replace_callback('#.-.#', function($m) {
@@ -35,7 +35,10 @@ class Random
 		}, $charlist));
 		$chLen = strlen($charlist);
 
-		if (function_exists('openssl_random_pseudo_bytes')) {
+		if (PHP_VERSION_ID >= 70000) {
+			$rand3 = random_bytes($length);
+		}
+		if (empty($rand3) && function_exists('openssl_random_pseudo_bytes')) {
 			$rand3 = openssl_random_pseudo_bytes($length);
 		}
 		if (empty($rand3) && function_exists('mcrypt_create_iv')) {

--- a/tests/Utils/Random.generate().no-mcrypt.phpt
+++ b/tests/Utils/Random.generate().no-mcrypt.phpt
@@ -1,7 +1,8 @@
 <?php
 
 /**
- * Test: Nette\Utils\Random::generate()
+ * Test: Nette\Utils\Random::generate() without openssl and mcrypt
+ * @phpIni disable_functions=openssl_random_pseudo_bytes,mcrypt_create_iv
  */
 
 use Nette\Utils\Random,
@@ -9,6 +10,11 @@ use Nette\Utils\Random,
 
 
 require __DIR__ . '/../bootstrap.php';
+
+
+if (!extension_loaded('mcrypt')) {
+	Tester\Environment::skip('Requires PHP extension mcrypt.');
+}
 
 
 Assert::same( 10, strlen(Random::generate()) );

--- a/tests/Utils/Random.generate().no-openssl.phpt
+++ b/tests/Utils/Random.generate().no-openssl.phpt
@@ -1,7 +1,8 @@
 <?php
 
 /**
- * Test: Nette\Utils\Random::generate()
+ * Test: Nette\Utils\Random::generate() without openssl
+ * @phpIni disable_functions=openssl_random_pseudo_bytes
  */
 
 use Nette\Utils\Random,
@@ -9,6 +10,11 @@ use Nette\Utils\Random,
 
 
 require __DIR__ . '/../bootstrap.php';
+
+
+if (!extension_loaded('openssl')) {
+	Tester\Environment::skip('Requires PHP extension OpenSSL.');
+}
 
 
 Assert::same( 10, strlen(Random::generate()) );

--- a/tests/php-win.ini
+++ b/tests/php-win.ini
@@ -3,6 +3,7 @@ extension_dir = "./ext"
 extension=php_mbstring.dll
 extension=php_gd2.dll
 extension=php_fileinfo.dll
+extension=php_openssl.dll
 
 [Zend]
 ;zend_extension="./ext/php_xdebug-2.0.5-5.3-vc6.dll"


### PR DESCRIPTION
Not sure whether the generateBytes() refactoring is worth it. It's still a bit ugly.