### PR TITLE
Revert "DateTime: workaround for changed signature of createFromFormat() in PHP 7 [closes #58]"

### DIFF
--- a/src/Utils/DateTime.php
+++ b/src/Utils/DateTime.php
@@ -10,9 +10,6 @@ namespace Nette\Utils;
 use Nette;
 
 
-// workaround for changed signature of createFromFormat in PHP 7
-@call_user_func(function() {
-
 /**
  * DateTime.
  *
@@ -137,5 +134,3 @@ class DateTime extends \DateTime implements \JsonSerializable
 	}
 
 }
-
-});


### PR DESCRIPTION
This reverts commit 85c4cd90029a152c4d6b61a256edb3ca7cd45ae4. Confirmed to work with the latest PHP 7 snapshot.