### PR TITLE
Json: accept whitespace-surrounded "null" for decode()

### DIFF
--- a/src/Utils/Json.php
+++ b/src/Utils/Json.php
@@ -89,7 +89,7 @@ class Json
 		}
 		$value = call_user_func_array('json_decode', $args);
 
-		if ($value === NULL && $json !== '' && strcasecmp($json, 'null')) { // '' is not clearing json_last_error
+		if ($value === NULL && $json !== '' && strcasecmp(trim($json, " \t\n\r"), 'null') !== 0) { // '' is not clearing json_last_error
 			$error = json_last_error();
 			throw new JsonException(isset(static::$messages[$error]) ? static::$messages[$error] : 'Unknown error', $error);
 		}

--- a/tests/Utils/Json.decode().phpt
+++ b/tests/Utils/Json.decode().phpt
@@ -15,6 +15,7 @@ Assert::same('ok', Json::decode('"ok"'));
 Assert::null(Json::decode(''));
 Assert::null(Json::decode('null'));
 Assert::null(Json::decode('NULL'));
+Assert::null(Json::decode(' null'));
 
 
 Assert::equal((object) ['a' => 1], Json::decode('{"a":1}'));


### PR DESCRIPTION
Json: accept whitespace-surrounded `"null"` for `decode()` as it is a valid JSON text. As the standard says: "Insignificant whitespace is allowed before or after any token." Therefore, `" null   "` and others are legal, although `Json` throws an exception for such input.