### PR TITLE
Trim Character Mask extracted into CONST

### DIFF
--- a/src/Utils/Strings.php
+++ b/src/Utils/Strings.php
@@ -16,6 +16,9 @@ use Nette;
 class Strings
 {
 
+	const TRIM_CHARACTERS = " \t\n\r\0\x0B\xC2\xA0";
+
+
 	/**
 	 * Static class - cannot be instantiated.
 	 */
@@ -370,7 +373,7 @@ class Strings
 	 * @param  string
 	 * @return string
 	 */
-	public static function trim($s, $charlist = " \t\n\r\0\x0B\xC2\xA0")
+	public static function trim($s, $charlist = self::TRIM_CHARACTERS)
 	{
 		$charlist = preg_quote($charlist, '#');
 		return self::replace($s, '#^['.$charlist.']+|['.$charlist.']+\z#u', '');


### PR DESCRIPTION
**BC break**: No
**Doc**: not-needed

**Motivation**: Sometimes I need trim also characters like  `ZERO WIDTH NO-BREAK SPACE` (yes, sadly there is an API that uses it in JSON response). If I want to use `Strings::trim` it forces me to *copy-paste* code for extending the character-mask.

```php
$zeroWithNoBreakSpace =  "\xEF\xBB\xBF";
Strings::trim($rawResponse, " \t\n\r\0\x0B\xC2\xA0" . $zeroWithNoBreakSpace);
```

vs. 

```php
$zeroWithNoBreakSpace =  "\xEF\xBB\xBF";
Strings::trim($rawResponse, Strings::TRIM_CHARACTER_MASK . $zeroWithNoBreakSpace);
```

***

**Note**: *I'm not really sure about naming for that constant. I will be happy if you suggest some better name.*
