### PR TITLE
Concept: Utils\DateTime deprecation & replacement

### DIFF
--- a/src/Utils/DateHelpers.php
+++ b/src/Utils/DateHelpers.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace Nette\Utils;
+
+use Nette;
+
+/**
+ * DateTime manipulation helpers.
+ */
+class DateHelpers
+{
+	/** minute in seconds */
+	const MINUTE = 60;
+
+	/** hour in seconds */
+	const HOUR = 60 * self::MINUTE;
+
+	/** day in seconds */
+	const DAY = 24 * self::HOUR;
+
+	/** week in seconds */
+	const WEEK = 7 * self::DAY;
+
+	/** average month in seconds */
+	const MONTH = 2629800;
+
+	/** average year in seconds */
+	const YEAR = 31557600;
+
+
+	public function __construct()
+	{
+		throw new Nette\StaticClassException;
+	}
+
+
+	/**
+	 * @param string|int|\DateTimeInterface $time
+	 * @return \DateTime
+	 */
+	public static function createMutable($time)
+	{
+		if ($time instanceof \DateTime) {
+			return clone $time;
+
+		} elseif ($time instanceof \DateTimeImmutable) {
+			return \DateTime::createFromImmutable($time);
+
+		} elseif (is_numeric($time)) {
+			if ($time <= self::YEAR) {
+				$time += time();
+			}
+			return (new \DateTime('@' . $time))->setTimeZone(new \DateTimeZone(date_default_timezone_get()));
+
+		} elseif ($time) {
+			return new \DateTime($time);
+
+		} else {
+			return new \DateTime();
+		}
+	}
+
+
+	/**
+	 * @param string|int|\DateTimeInterface $time
+	 * @return \DateTimeImmutable
+	 */
+	public static function createImmutable($time)
+	{
+		if ($time instanceof \DateTimeImmutable) {
+			return clone $time;
+
+		} elseif ($time instanceof \Datetime) {
+			return \DateTimeImmutable::createFromMutable($time);
+
+		} elseif (is_numeric($time)) {
+			if ($time <= self::YEAR) {
+				$time += time();
+			}
+			return (new \DateTimeImmutable('@' . $time))->setTimeZone(new \DateTimeZone(date_default_timezone_get()));
+
+		} elseif ($time) {
+			return new \DateTimeImmutable($time);
+
+		} else {
+			return new \DateTimeImmutable();
+		}
+	}
+
+
+	/**
+	 * Returns new \DateTime object formatted according to the specified format or FALSE on failure.
+	 * @param string The format the $time parameter should be in
+	 * @param string String representing the time
+	 * @param string|\DateTimeZone desired timezone (default timezone is used if NULL is passed)
+	 * @return \DateTime|FALSE
+	 */
+	public static function createMutableFromFormat($format, $time, $timezone = NULL)
+	{
+		$timezone = self::checkTimezone($timezone);
+		return \DateTime::createFromFormat($format, $time, $timezone);
+	}
+
+
+	/**
+	 * Returns new \DateTimeImmutable object formatted according to the specified format or FALSE on failure.
+	 * @param string The format the $time parameter should be in
+	 * @param string String representing the time
+	 * @param string|\DateTimeZone desired timezone (default timezone is used if NULL is passed)
+	 * @return \DateTimeImmutable|FALSE
+	 */
+	public static function createImmutableFromFormat($format, $time, $timezone = NULL)
+	{
+		$timezone = self::checkTimezone($timezone);
+		return \DateTimeImmutable::createFromFormat($format, $time, $timezone);
+	}
+
+
+	/**
+	 * @param string
+	 * @return \DateTimeZone
+	 */
+	private static function checkTimezone($timezone = NULL)
+	{
+		if ($timezone === NULL) {
+			return new \DateTimeZone(date_default_timezone_get());
+
+		} elseif (is_string($timezone)) {
+			return new \DateTimeZone($timezone);
+
+		} elseif (!$timezone instanceof \DateTimeZone) {
+			throw new Nette\InvalidArgumentException('Invalid timezone given');
+		}
+	}
+
+
+	/**
+	 * @param \DateTimeInterface
+	 * @param string
+	 * @return \DateTimeInterface
+	 */
+	public static function modifyClone(\DateTimeInterface $dateTime, $modify = '')
+	{
+		if ($dateTime instanceof \DateTimeImmutable) {
+			return $modify ? $dateTime->modify($modify) : clone $dateTime;
+		}
+
+		$dateTime = clone $dateTime;
+		return $modify ? $dateTime->modify($modify) : $dateTime;
+	}
+
+
+	/**
+	 * @param  \DateTimeInterface
+	 * @param  int
+	 * @return \DateTimeInterface
+	 */
+	public static function setTimestamp(\DateTimeInterface $dateTime, $timestamp)
+	{
+		$zone = $dateTime->getTimezone();
+
+		if ($dateTime instanceof \DateTimeImmutable) {
+			return (new \DateTimeImmutable('@' . $timestamp))->setTimezone($zone);
+		}
+
+		$dateTime->__construct('@' . $timestamp);
+		return $dateTime->setTimeZone($zone);
+	}
+
+
+	/**
+	 * @param \DateTimeInterface
+	 * @return int|string
+	 */
+	public static function getTimestamp(\DateTimeInterface $dateTime)
+	{
+		$ts = $dateTime->format('U');
+		return is_float($tmp = $ts * 1) ? $ts : $tmp;
+	}
+}

--- a/src/Utils/DateTime.php
+++ b/src/Utils/DateTime.php
@@ -7,32 +7,39 @@
 
 namespace Nette\Utils;
 
+use DateTimeZone;
 use Nette;
 
 
 /**
+ * @deprecated Use Nette\Utils\DateHelpers.
  * DateTime.
  */
 class DateTime extends \DateTime implements \JsonSerializable
 {
 	/** minute in seconds */
-	const MINUTE = 60;
+	const MINUTE = DateHelpers::MINUTE;
 
 	/** hour in seconds */
-	const HOUR = 60 * self::MINUTE;
+	const HOUR = DateHelpers::HOUR;
 
 	/** day in seconds */
-	const DAY = 24 * self::HOUR;
+	const DAY = DateHelpers::DAY;
 
 	/** week in seconds */
-	const WEEK = 7 * self::DAY;
+	const WEEK = DateHelpers::WEEK;
 
 	/** average month in seconds */
-	const MONTH = 2629800;
+	const MONTH = DateHelpers::MONTH;
 
 	/** average year in seconds */
-	const YEAR = 31557600;
+	const YEAR = DateHelpers::YEAR;
 
+	public function __construct($time = 'now', DateTimeZone $timezone = NULL)
+	{
+		trigger_error('Class ' . __CLASS__ . ' is deprecated, please use ' . DateHelpers::class . ' instead.', E_USER_DEPRECATED);
+		parent::__construct($time, $timezone);
+	}
 
 	/**
 	 * DateTime object factory.
@@ -71,8 +78,7 @@ class DateTime extends \DateTime implements \JsonSerializable
 	 */
 	public function modifyClone($modify = '')
 	{
-		$dolly = clone $this;
-		return $modify ? $dolly->modify($modify) : $dolly;
+		return DateHelpers::modifyClone($this, $modify);
 	}
 
 
@@ -82,9 +88,7 @@ class DateTime extends \DateTime implements \JsonSerializable
 	 */
 	public function setTimestamp($timestamp)
 	{
-		$zone = $this->getTimezone();
-		$this->__construct('@' . $timestamp);
-		return $this->setTimeZone($zone);
+		return DateHelpers::setTimestamp($this, $timestamp);
 	}
 
 
@@ -93,8 +97,7 @@ class DateTime extends \DateTime implements \JsonSerializable
 	 */
 	public function getTimestamp()
 	{
-		$ts = $this->format('U');
-		return is_float($tmp = $ts * 1) ? $ts : $tmp;
+		return DateHelpers::getTimestamp($this);
 	}
 
 

--- a/tests/Utils/Arrays.associate().phpt
+++ b/tests/Utils/Arrays.associate().phpt
@@ -193,14 +193,30 @@ Assert::same(
 
 // allowes objects in keys
 Assert::equal(
-	['2014-02-05 00:00:00' => new DateTime('2014-02-05')],
+	['2014-02-05 nette' => new Foo('2014-02-05')],
 	Arrays::associate($arr = [
-		['date' => new DateTime('2014-02-05')],
+		['date' => new Foo('2014-02-05')],
 	], 'date=date')
 );
 Assert::equal(
-	(object) ['2014-02-05 00:00:00' => new DateTime('2014-02-05')],
+	(object) ['2014-02-05 nette' => new Foo('2014-02-05')],
 	Arrays::associate($arr = [
-		['date' => new DateTime('2014-02-05')],
+		['date' => new Foo('2014-02-05')],
 	], '->date=date')
 );
+
+
+class Foo
+{
+	private $value;
+
+	public function __construct($value)
+	{
+		$this->value = $value;
+	}
+
+	public function __toString()
+	{
+		return $this->value . ' nette';
+	}
+}

--- a/tests/Utils/DateHelpers.createImmutable.phpt
+++ b/tests/Utils/DateHelpers.createImmutable.phpt
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Test: Nette\Utils\DateHelpers::createImmutable().
+ */
+
+use Tester\Assert;
+use Nette\Utils\DateHelpers;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+date_default_timezone_set('Europe/Prague');
+
+const FORMAT = 'Y-m-d H:i:s';
+
+Assert::same('1978-01-23 11:40:00', DateHelpers::createImmutable(254400000)->format(FORMAT));
+Assert::same(254400000, DateHelpers::createImmutable(254400000)->getTimestamp());
+
+Assert::same('2050-08-13 11:40:00', DateHelpers::createImmutable(2544000000)->format(FORMAT));
+Assert::same(is_int(2544000000) ? 2544000000 : '2544000000', DateHelpers::createImmutable(2544000000)->getTimestamp()); // 64 bit
+
+Assert::same('1978-05-05 00:00:00', DateHelpers::createImmutable('1978-05-05')->format(FORMAT));
+
+Assert::type(DateTimeImmutable::class, DateHelpers::createImmutable(new DateTime('1978-05-05')));
+
+Assert::same('1978-05-05 00:00:00', DateHelpers::createImmutable(new DateTime('1978-05-05'))->format(FORMAT));

--- a/tests/Utils/DateHelpers.createMutable.phpt
+++ b/tests/Utils/DateHelpers.createMutable.phpt
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Test: Nette\Utils\DateHelpers::createMutable().
+ */
+
+use Tester\Assert;
+use Nette\Utils\DateHelpers;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+date_default_timezone_set('Europe/Prague');
+
+const FORMAT = 'Y-m-d H:i:s';
+
+Assert::same('1978-01-23 11:40:00', DateHelpers::createMutable(254400000)->format(FORMAT));
+Assert::same(254400000, DateHelpers::createMutable(254400000)->getTimestamp());
+
+Assert::same('2050-08-13 11:40:00', DateHelpers::createMutable(2544000000)->format(FORMAT));
+Assert::same(is_int(2544000000) ? 2544000000 : '2544000000', DateHelpers::createMutable(2544000000)->getTimestamp()); // 64 bit
+
+Assert::same('1978-05-05 00:00:00', DateHelpers::createMutable('1978-05-05')->format(FORMAT));
+
+Assert::type(DateTime::class, DateHelpers::createMutable(new DateTime('1978-05-05')));
+
+Assert::same('1978-05-05 00:00:00', DateHelpers::createMutable(new DateTime('1978-05-05'))->format(FORMAT));

--- a/tests/Utils/DateHelpers.getTimestamp.phpt
+++ b/tests/Utils/DateHelpers.getTimestamp.phpt
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Test: Nette\DateHelpers::getTimestamp().
+ */
+
+use Tester\Assert;
+use Nette\Utils\DateHelpers;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+date_default_timezone_set('Europe/Prague');
+
+$timestamp = 123456789;
+
+$mutable = DateHelpers::createMutable($timestamp);
+Assert::same($timestamp, $mutable->getTimestamp());
+
+$immutable = DateHelpers::createImmutable($timestamp);
+Assert::same($timestamp, $immutable->getTimestamp());

--- a/tests/Utils/DateHelpers.modifyClone.phpt
+++ b/tests/Utils/DateHelpers.modifyClone.phpt
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Test: Nette\Utils\DateHelpers::modifyClone().
+ */
+
+use Tester\Assert;
+use Nette\Utils\DateHelpers;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+date_default_timezone_set('Europe/Prague');
+
+$timestamp = 123456789;
+$offset = 1000;
+
+// test mutable
+$mutable = DateHelpers::createMutable($timestamp);
+$newMutable = DateHelpers::modifyClone($mutable, "+$offset seconds");
+Assert::type(DateTime::class, $newMutable);
+Assert::notSame($mutable, $newMutable);
+Assert::same($timestamp, $mutable->getTimestamp());
+Assert::same($timestamp + $offset, $newMutable->getTimestamp());
+
+// test immutable
+$immutable = DateHelpers::createImmutable($timestamp);
+$newImmutable = DateHelpers::modifyClone($immutable, "+$offset seconds");
+Assert::type(DateTimeImmutable::class, $newImmutable);
+Assert::notSame($immutable, $newImmutable);
+Assert::same($timestamp, $immutable->getTimestamp());
+Assert::same($timestamp + $offset, $newImmutable->getTimestamp());

--- a/tests/Utils/DateHelpers.setTimestamp.phpt
+++ b/tests/Utils/DateHelpers.setTimestamp.phpt
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Test: Nette\Utils\DateHelpers::setTimestamp().
+ */
+
+use Tester\Assert;
+use Nette\Utils\DateHelpers;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+date_default_timezone_set('Europe/Prague');
+
+$timestamp = 123456789;
+$newTimestamp = $timestamp + 1000;
+
+$mutable = DateHelpers::createMutable($timestamp);
+$changedMutable = $mutable->setTimestamp($newTimestamp);
+Assert::same($mutable, $changedMutable);
+Assert::same($newTimestamp, $mutable->getTimestamp());
+Assert::same($newTimestamp, $changedMutable->getTimestamp());
+
+$immutable = DateHelpers::createImmutable($timestamp);
+$changedImmutable = $immutable->setTimestamp($newTimestamp);
+Assert::notSame($immutable, $changedImmutable);
+Assert::same($timestamp, $immutable->getTimestamp());
+Assert::same($newTimestamp, $changedImmutable->getTimestamp());

--- a/tests/Utils/DateTime.JSON.phpt
+++ b/tests/Utils/DateTime.JSON.phpt
@@ -9,6 +9,8 @@ use Nette\Utils\DateTime;
 
 require __DIR__ . '/../bootstrap.php';
 
+error_reporting(error_reporting() & ~E_USER_DEPRECATED);
+
 
 date_default_timezone_set('Europe/Prague');
 

--- a/tests/Utils/DateTime.createFromFormat.phpt
+++ b/tests/Utils/DateTime.createFromFormat.phpt
@@ -9,6 +9,8 @@ use Nette\Utils\DateTime;
 
 require __DIR__ . '/../bootstrap.php';
 
+error_reporting(error_reporting() & ~E_USER_DEPRECATED);
+
 
 date_default_timezone_set('Europe/Prague');
 

--- a/tests/Utils/DateTime.createFromFormat.phpt
+++ b/tests/Utils/DateTime.createFromFormat.phpt
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Test: Nette\DateTime::createFromFormat().
+ * Test: Nette\Utils\DateTime::createFromFormat().
  */
 
 use Tester\Assert;

--- a/tests/Utils/DateTime.from.phpt
+++ b/tests/Utils/DateTime.from.phpt
@@ -9,6 +9,8 @@ use Nette\Utils\DateTime;
 
 require __DIR__ . '/../bootstrap.php';
 
+error_reporting(error_reporting() & ~E_USER_DEPRECATED);
+
 
 date_default_timezone_set('Europe/Prague');
 

--- a/tests/Utils/DateTime.getTimestamp.phpt
+++ b/tests/Utils/DateTime.getTimestamp.phpt
@@ -9,6 +9,8 @@ use Nette\Utils\DateTime;
 
 require __DIR__ . '/../bootstrap.php';
 
+error_reporting(error_reporting() & ~E_USER_DEPRECATED);
+
 
 date_default_timezone_set('Europe/Prague');
 

--- a/tests/Utils/DateTime.getTimestamp.phpt
+++ b/tests/Utils/DateTime.getTimestamp.phpt
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Test: Nette\Utils\DateTime::getTimestamp().
+ */
+
+use Tester\Assert;
+use Nette\Utils\DateTime;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+date_default_timezone_set('Europe/Prague');
+
+$timestamp = 123456789;
+$dt = DateTime::from($timestamp);
+Assert::same($timestamp, $dt->getTimestamp());

--- a/tests/Utils/DateTime.modifyClone.phpt
+++ b/tests/Utils/DateTime.modifyClone.phpt
@@ -9,6 +9,8 @@ use Nette\Utils\DateTime;
 
 require __DIR__ . '/../bootstrap.php';
 
+error_reporting(error_reporting() & ~E_USER_DEPRECATED);
+
 
 date_default_timezone_set('Europe/Prague');
 

--- a/tests/Utils/DateTime.modifyClone.phpt
+++ b/tests/Utils/DateTime.modifyClone.phpt
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Test: Nette\Utils\DateTime::modifyClone().
+ */
+
+use Tester\Assert;
+use Nette\Utils\DateTime;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+date_default_timezone_set('Europe/Prague');
+
+$timestamp = 123456789;
+$offset = 1000;
+
+$dt = DateTime::from($timestamp);
+$newDt = $dt->modifyClone("+$offset seconds");
+Assert::notSame($dt, $newDt);
+Assert::same($timestamp, $dt->getTimestamp());
+Assert::same($timestamp + $offset, $newDt->getTimestamp());

--- a/tests/Utils/DateTime.setTimestamp.phpt
+++ b/tests/Utils/DateTime.setTimestamp.phpt
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Test: Nette\Utils\DateTime::setTimestamp().
+ */
+
+use Tester\Assert;
+use Nette\Utils\DateTime;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+date_default_timezone_set('Europe/Prague');
+
+$timestamp = 123456789;
+$newTimestamp = $timestamp + 1000;
+$dt = DateTime::from($timestamp);
+$dt->setTimestamp($newTimestamp);
+Assert::same($newTimestamp, $dt->getTimestamp());
+Assert::same((string) $newTimestamp, $dt->format('U'));

--- a/tests/Utils/DateTime.setTimestamp.phpt
+++ b/tests/Utils/DateTime.setTimestamp.phpt
@@ -9,6 +9,8 @@ use Nette\Utils\DateTime;
 
 require __DIR__ . '/../bootstrap.php';
 
+error_reporting(error_reporting() & ~E_USER_DEPRECATED);
+
 
 date_default_timezone_set('Europe/Prague');
 


### PR DESCRIPTION
Hi,

this is an attempt to phase out `Nette\Utils\DateTime` and replace it by a new helper class.
The current DateTime makes date & time manipulation easier since it enhances `\DateTime`, yet it has some major flaws: mutability and inheritance.

Why should we want the new helper class?
- current DateTime contains some useful methods to ease manipulation with DateTime instance, these are moved to this new class;
- supports both mutable `\DateTime` and immutable `\DateTimeImmutable` variants, through `\DateTimeInterface`;
- inheritance-free, does not extend mutable `\DateTime`;
- does not provide magical __toString (which by the way drops the time zone information).

This PR is a draft, not a final proposal yet. It consists of new tests for existing DateTIme class as well as the actual replacement with tests as well.

I'd like to hear some feedback -- whether is it really what we want (I hope so) and what & how could be eventually changed.

(This depends on #79 which bumps composer.json & Travis versions. Hence Travis fails.)
