### PR TITLE
Strings: Allow to specify separator in webalize()

### DIFF
--- a/src/Utils/Strings.php
+++ b/src/Utils/Strings.php
@@ -196,17 +196,18 @@ class Strings
 	 * Converts to web safe characters [a-z0-9-] text.
 	 * @param  string  UTF-8 encoding
 	 * @param  string  allowed characters
+	 * @param  string  Whitespace separator
 	 * @param  bool
 	 * @return string
 	 */
-	public static function webalize($s, $charlist = NULL, $lower = TRUE)
+	public static function webalize($s, $charlist = NULL, $lower = TRUE, $separator = '-')
 	{
 		$s = self::toAscii($s);
 		if ($lower) {
 			$s = strtolower($s);
 		}
-		$s = preg_replace('#[^a-z0-9' . ($charlist !== NULL ? preg_quote($charlist, '#') : '') . ']+#i', '-', $s);
-		$s = trim($s, '-');
+		$s = preg_replace('#[^a-z0-9' . ($charlist !== NULL ? preg_quote($charlist, '#') : '') . ']+#i', $separator, $s);
+		$s = trim($s, $separator);
 		return $s;
 	}
 

--- a/tests/Utils/Strings.webalize().phpt
+++ b/tests/Utils/Strings.webalize().phpt
@@ -15,3 +15,5 @@ Assert::same('zlutoucky-kun-oooo', Strings::webalize("&\xc5\xbdLU\xc5\xa4OU\xc4\
 Assert::same('ZLUTOUCKY-KUN-oooo', Strings::webalize("&\xc5\xbdLU\xc5\xa4OU\xc4\x8cK\xc3\x9d K\xc5\xae\xc5\x87 \xc3\xb6\xc5\x91\xc3\xb4o!", NULL, FALSE)); // &ŽLUŤOUČKÝ KŮŇ öőôo!
 Assert::same('1-4-!',  Strings::webalize("\xc2\xBC !", '!'));
 Assert::same('a-b', Strings::webalize("a\xC2\xA0b")); // non-breaking space
+Assert::same('1_2_3', Strings::webalize('1 2 3', NULL, TRUE, '_'));
+Assert::same('zlutoucky kun', Strings::webalize('Žlutoučký kůň', NULL, TRUE, ' '));


### PR DESCRIPTION
It's helpful if you need remove accents from string and change whitespace separator to something else then `_`.