### PR TITLE
Json::encode - pass all options to json_encode

### DIFF
--- a/src/Utils/Json.php
+++ b/src/Utils/Json.php
@@ -16,7 +16,7 @@ use Nette;
 class Json
 {
 	const FORCE_ARRAY = 0b0001;
-	const PRETTY = 0b0010;
+	const PRETTY = JSON_PRETTY_PRINT;
 
 
 	/**
@@ -36,9 +36,7 @@ class Json
 	 */
 	public static function encode($value, $options = 0)
 	{
-		$flags = JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | ($options & self::PRETTY ? JSON_PRETTY_PRINT : 0);
-
-		$json = json_encode($value, $flags);
+		$json = json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | $options);
 		if ($error = json_last_error()) {
 			throw new JsonException(json_last_error_msg(), $error);
 		}

--- a/tests/Utils/Json.encode().phpt
+++ b/tests/Utils/Json.encode().phpt
@@ -37,3 +37,14 @@ Assert::same("[\n    1,\n    2,\n    3\n]", Json::encode([1, 2, 3], Json::PRETTY
 Assert::exception(function () {
 	Json::encode(NAN);
 }, Nette\Utils\JsonException::class, 'Inf and NaN cannot be JSON encoded');
+
+// passing all options to json_encode
+Assert::same("\"'\"", Json::encode("'"));
+Assert::same('"\u0027"', Json::encode("'", JSON_HEX_APOS));
+
+// JSON_PRESERVE_ZERO_FRACTION
+Assert::same('25', Json::encode(25.0));
+
+if (PHP_VERSION_ID >= 50606) {
+	Assert::same('25.0', Json::encode(25.0, JSON_PRESERVE_ZERO_FRACTION));
+}


### PR DESCRIPTION
Main motivation is to be able to use `JSON_PRESERVE_ZERO_FRACTION` while still benefitting from other features of Json::encode like error detection.

There are no intentional BC breaks involved.