### PR TITLE
Allow pass flag = 0 to json_encode on PHP5.4+

### DIFF
--- a/src/Utils/Json.php
+++ b/src/Utils/Json.php
@@ -17,7 +17,7 @@ class Json
 {
 	const FORCE_ARRAY = 0b0001;
 	const PRETTY = 0b0010;
-
+	const UGLY = 0b0011;
 
 	/**
 	 * Static class - cannot be instantiated.
@@ -36,9 +36,9 @@ class Json
 	 */
 	public static function encode($value, $options = 0)
 	{
-		$flags = JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES
+		$flags = $options & self::UGLY ? 0 : (JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES
 			| ($options & self::PRETTY ? JSON_PRETTY_PRINT : 0)
-			| (defined('JSON_PRESERVE_ZERO_FRACTION') ? JSON_PRESERVE_ZERO_FRACTION : 0); // since PHP 5.6.6 & PECL JSON-C 1.3.7
+			| (defined('JSON_PRESERVE_ZERO_FRACTION') ? JSON_PRESERVE_ZERO_FRACTION : 0)); // since PHP 5.6.6 & PECL JSON-C 1.3.7
 
 		$json = json_encode($value, $flags);
 		if ($error = json_last_error()) {


### PR DESCRIPTION
```
$array = ['tag' => 'Odómetro'];

\Nette\Utils\Json::encode($array); //"{"Tag":"Odómetro"}"
```

Needed behaviour:

`\Nette\Utils\Json::encode($array, \Nette\Utils\Json::UGLY); //"{"Tag":"Od\u00f3metro"}"`