### PR TITLE
FileSystem: fix mkdir race condition

### DIFF
--- a/src/Utils/FileSystem.php
+++ b/src/Utils/FileSystem.php
@@ -24,7 +24,7 @@ class FileSystem
 	 */
 	public static function createDir($dir, $mode = 0777)
 	{
-		if (!is_dir($dir) && !@mkdir($dir, $mode, TRUE)) { // intentionally @; not atomic
+		if (!is_dir($dir) && !@mkdir($dir, $mode, TRUE) && !is_dir($dir)) { // intentionally @; not atomic
 			throw new Nette\IOException("Unable to create directory '$dir'.");
 		}
 	}


### PR DESCRIPTION
Directory can be created by concurrent process. Similar solution by Symfony in this issue https://github.com/symfony/symfony/pull/11726