### PR TITLE
Add Nette\Utils\Collection

### DIFF
--- a/src/Utils/Collection.php
+++ b/src/Utils/Collection.php
@@ -1,0 +1,204 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (https://nette.org)
+ * Copyright (c) 2004 David Grudl (https://davidgrudl.com)
+ */
+
+declare(strict_types=1);
+
+namespace Nette\Utils;
+
+use Nette;
+
+
+/**
+ * Collection of items (probably of same type).
+ */
+abstract class Collection
+{
+
+	/** @var array */
+	private $items = [];
+
+	/** @var bool */
+	private $keysMatter = FALSE;
+
+
+	/**
+	 * @return static
+	 * @throws Nette\NotSupportedException
+	 */
+	public static function fromIterator(\Traversable $iterator, array $constructorArgs = [])
+	{
+		$me = new static(...array_values($constructorArgs));
+		if (!method_exists($me, 'add')) {
+			throw new Nette\NotSupportedException(__METHOD__ . '() requires ' . get_class($me) . '::add() to be implemented.');
+		}
+
+		foreach ($iterator as $item) {
+			$me->add($item);
+		}
+
+		return $me;
+	}
+
+
+	/**
+	 * @return static
+	 * @throws Nette\NotSupportedException
+	 */
+	public static function fromArray(array $items, array $constructorArgs = [])
+	{
+		return static::fromIterator(new \ArrayIterator($items), $constructorArgs);
+	}
+
+
+	/**
+	 * @return int
+	 */
+	public function count()
+	{
+		return count($this->items);
+	}
+
+
+	/**
+	 * @param  mixed
+	 * @return bool
+	 */
+	public function has($key)
+	{
+		return array_key_exists($this->normalizeKey($key), $this->items);
+	}
+
+
+	/**
+	 * @return array
+	 */
+	public function getKeys()
+	{
+		return array_keys($this->items);
+	}
+
+
+	/**
+	 * @return \ArrayIterator
+	 */
+	public function getIterator()
+	{
+		return new \ArrayIterator($this->items);
+	}
+
+
+	/**
+	 * @param  callable
+	 * @return static
+	 */
+	public function filter(callable $cb)
+	{
+		$me = clone $this;
+		$me->items = array_filter($this->items, $cb, ARRAY_FILTER_USE_BOTH);
+		return $me;
+	}
+
+
+	/**
+	 * @param  callable
+	 * @return static
+	 */
+	public function walk(callable $cb)
+	{
+		array_walk($this->items, $cb);
+		return $this;
+	}
+
+
+	/**
+	 * @param  callable
+	 * @return array
+	 */
+	public function convert(callable $cb)
+	{
+		$result = [];
+		foreach ($this->items as $key => $item) {
+			$unset = FALSE;
+			$item = $cb($item, $key, $unset);
+			if (!$unset) {
+				if ($key === NULL) {
+					$result[] = $item;
+				} else {
+					$result[$key] = $item;
+				}
+			}
+		}
+
+		return $result;
+	}
+
+
+	/**
+	 * @param  callable $cb
+	 * @return static
+	 */
+	public function sortBy(callable $cb)
+	{
+		if ($this->keysMatter) {
+			uasort($this->items, $cb);
+		} else {
+			usort($this->items, $cb);
+		}
+
+		return $this;
+	}
+
+
+	/**
+	 * @param  mixed $key
+	 * @return int|string
+	 */
+	protected function normalizeKey($key)
+	{
+		return $key;
+	}
+
+
+	/**
+	 * @param  mixed
+	 * @param  mixed
+	 * @throws Nette\ArgumentOutOfRangeException
+	 * @return void
+	 */
+	protected function addItem($item, $key)
+	{
+		$key = $this->normalizeKey($key);
+
+		if ($key === NULL) {
+			$this->items[] = $item;
+		} else {
+			if (array_key_exists($key, $this->items)) {
+				throw new Nette\ArgumentOutOfRangeException("Item with key '$key' already exists in " . get_class($this) . " collection.");
+			}
+			$this->items[$key] = $item;
+			$this->keysMatter = TRUE;
+		}
+	}
+
+
+	/**
+	 * @param  mixed
+	 * @return mixed
+	 * @throws ItemNotFoundException
+	 */
+	protected function getItem($key)
+	{
+		$key = $this->normalizeKey($key);
+
+		if (!array_key_exists($key, $this->items)) {
+			throw new ItemNotFoundException("Item with key '$key' was not found in collection.");
+		}
+
+		return $this->items[$key];
+	}
+
+}

--- a/src/Utils/exceptions.php
+++ b/src/Utils/exceptions.php
@@ -117,6 +117,8 @@ class StaticClassException extends \LogicException
 
 namespace Nette\Utils;
 
+use Nette;
+
 
 /**
  * The exception that is thrown when an image error occurs.
@@ -154,5 +156,13 @@ class RegexpException extends \Exception
  * The exception that indicates assertion error.
  */
 class AssertionException extends \Exception
+{
+}
+
+
+/**
+ * The exception indicates that item is not present in collection.
+ */
+class ItemNotFoundException extends Nette\ArgumentOutOfRangeException
 {
 }


### PR DESCRIPTION
- bug fix? no
- new feature? yes
- BC break? no
- doc PR: will

I'm using this abstract collection really often. Its purpose is to emulate typed array in most cases.

May seem to be strange that methods like `get()` or `add()` are missing. It is because of PHP invariance limitation.

An example of basic usage:
```php
# One item for collection
class Person
{
    public $email;
    public $firstName;
    public $lastname;
    public $username;
}

# Collection itself
class People extends Nette\Utils\Collection
{
    public function add(Person $person): People
    {
        $this->addItem($person, $person->username);
        return $this;
    }

    public function get(string $username): Person
    {
        return $this->getItem($username);
    }
}


# Creating collection
$people = People::fromIterator(...);

# If good friend Joe is here...
if ($people->has('joe')) {
	debug("Joe is here... again.");
}


# Example usage: create an array of emails, only if email is set
$emails = $people->convert(function (Person $person, $key, & $unset) {
	$unset = $person->email === NULL;
	return $person->email;
});
```

Collection can declare frequent helpers on self:
```php
# Sorting example
public function sortDefault()
{
	$this->sortBy(function (Person $a, Person $b) {
		if ($a->username === 'joe') return -1;  # sorry joe
		return $a->username <=> $b->username;
	});
}

# Coversion to array for Form <select> input
public function forSelectInput()
{
	return $this->convert(function (Person $person) {
		return "$person->lastname $person->firstName";
	});
}
```

And usage as typed array:
```php
class Mailer
{
	public function mail(People $people, Mail $message)
	{
		$people->walk(function (Person $person) use ($message) {
			$this->senfTo($person->email, $message);
		});
	}
}
```

The `IteratorAggreagete` is here for ordinary loops, like:
```php

/** @var People|Person[] $people */
$people = ...;
foreach ($people as $person) {

)
```

The `ArrayAccess` is not implemented. I tried that, but never found it useful.

The `normalizeKey()` method can convert complex types to scalar, for example for multi column primary keys in database. On the other hand, I overloaded it very rarely.

If this would be accepted, I'll add tests and doc.
