### PR TITLE
Returns NULL instead of FALSE on error

### DIFF
--- a/src/Utils/Arrays.php
+++ b/src/Utils/Arrays.php
@@ -78,12 +78,12 @@ class Arrays
 
 	/**
 	 * Searches the array for a given key and returns the offset if successful.
-	 * @return int|FALSE offset if it is found, FALSE otherwise
+	 * @return int|NULL offset if it is found, NULL otherwise
 	 */
 	public static function searchKey(array $arr, $key)
 	{
 		$foo = [$key => NULL];
-		return array_search(key($foo), array_keys($arr), TRUE);
+		return ($tmp = array_search(key($foo), array_keys($arr), TRUE)) === FALSE ? NULL : $tmp;
 	}
 
 
@@ -105,7 +105,7 @@ class Arrays
 	public static function insertAfter(array &$arr, $key, array $inserted)
 	{
 		$offset = self::searchKey($arr, $key);
-		$offset = $offset === FALSE ? count($arr) : $offset + 1;
+		$offset = $offset === NULL ? count($arr) : $offset + 1;
 		$arr = array_slice($arr, 0, $offset, TRUE) + $inserted + array_slice($arr, $offset, count($arr), TRUE);
 	}
 
@@ -117,7 +117,7 @@ class Arrays
 	public static function renameKey(array &$arr, $oldKey, $newKey)
 	{
 		$offset = self::searchKey($arr, $oldKey);
-		if ($offset !== FALSE) {
+		if ($offset !== NULL) {
 			$keys = array_keys($arr);
 			$keys[$offset] = $newKey;
 			$arr = array_combine($keys, $arr);

--- a/src/Utils/DateTime.php
+++ b/src/Utils/DateTime.php
@@ -117,7 +117,7 @@ class DateTime extends \DateTime implements \JsonSerializable
 	 * @param  string The format the $time parameter should be in
 	 * @param  string String representing the time
 	 * @param  string|\DateTimeZone desired timezone (default timezone is used if NULL is passed)
-	 * @return static|FALSE
+	 * @return static|NULL
 	 */
 	public static function createFromFormat($format, $time, $timezone = NULL)
 	{
@@ -132,7 +132,7 @@ class DateTime extends \DateTime implements \JsonSerializable
 		}
 
 		$date = parent::createFromFormat($format, $time, $timezone);
-		return $date ? static::from($date) : FALSE;
+		return $date ? static::from($date) : NULL;
 	}
 
 

--- a/src/Utils/Strings.php
+++ b/src/Utils/Strings.php
@@ -353,51 +353,51 @@ class Strings
 
 	/**
 	 * Returns part of $haystack before $nth occurence of $needle (negative value means searching from the end).
-	 * @return string|FALSE  returns FALSE if the needle was not found
+	 * @return string|NULL  returns NULL if the needle was not found
 	 */
 	public static function before(string $haystack, string $needle, int $nth = 1)
 	{
 		$pos = self::pos($haystack, $needle, $nth);
-		return $pos === FALSE
-			? FALSE
+		return $pos === NULL
+			? NULL
 			: substr($haystack, 0, $pos);
 	}
 
 
 	/**
 	 * Returns part of $haystack after $nth occurence of $needle (negative value means searching from the end).
-	 * @return string|FALSE  returns FALSE if the needle was not found
+	 * @return string|NULL  returns NULL if the needle was not found
 	 */
 	public static function after(string $haystack, string $needle, int $nth = 1)
 	{
 		$pos = self::pos($haystack, $needle, $nth);
-		return $pos === FALSE
-			? FALSE
+		return $pos === NULL
+			? NULL
 			: substr($haystack, $pos + strlen($needle));
 	}
 
 
 	/**
 	 * Returns position of $nth occurence of $needle in $haystack (negative value means searching from the end).
-	 * @return int|FALSE  offset in characters or FALSE if the needle was not found
+	 * @return int|NULL  offset in characters or NULL if the needle was not found
 	 */
 	public static function indexOf(string $haystack, string $needle, int $nth = 1)
 	{
 		$pos = self::pos($haystack, $needle, $nth);
-		return $pos === FALSE
-			? FALSE
+		return $pos === NULL
+			? NULL
 			: self::length(substr($haystack, 0, $pos));
 	}
 
 
 	/**
 	 * Returns position of $nth occurence of $needle in $haystack.
-	 * @return int|FALSE  offset in bytes or FALSE if the needle was not found
+	 * @return int|NULL  offset in bytes or NULL if the needle was not found
 	 */
 	private static function pos(string $haystack, string $needle, int $nth = 1)
 	{
 		if (!$nth) {
-			return FALSE;
+			return NULL;
 		} elseif ($nth > 0) {
 			if (strlen($needle) === 0) {
 				return 0;
@@ -416,7 +416,7 @@ class Strings
 				$pos--;
 			}
 		}
-		return $pos;
+		return $pos === FALSE ? NULL : $pos;
 	}
 
 

--- a/tests/Utils/Arrays.searchKey().phpt
+++ b/tests/Utils/Arrays.searchKey().phpt
@@ -33,4 +33,4 @@ Assert::same(2, Arrays::searchKey($arr, 1));
 Assert::same(1, Arrays::searchKey($arr, 0));
 Assert::same(0, Arrays::searchKey($arr, NULL));
 Assert::same(0, Arrays::searchKey($arr, ''));
-Assert::false(Arrays::searchKey($arr, 'undefined'));
+Assert::null(Arrays::searchKey($arr, 'undefined'));

--- a/tests/Utils/DateTime.createFromFormat.phpt
+++ b/tests/Utils/DateTime.createFromFormat.phpt
@@ -26,4 +26,4 @@ Assert::error(function () {
 	DateTime::createFromFormat('Y-m-d H:i:s', '2050-08-13 11:40:00', 5);
 }, Nette\InvalidArgumentException::class, 'Invalid timezone given');
 
-Assert::false(DateTime::createFromFormat('Y-m-d', '2014-10'));
+Assert::null(DateTime::createFromFormat('Y-m-d', '2014-10'));

--- a/tests/Utils/Strings.after().phpt
+++ b/tests/Utils/Strings.after().phpt
@@ -27,10 +27,10 @@ test(function () {
 	Assert::same('c', Strings::after($foo, '789', 3));
 	Assert::same('a123456789b123456789c', Strings::after($foo, '9', -3));
 	Assert::same('a123456789b123456789c', Strings::after($foo, '789', -3));
-	Assert::false(Strings::after($foo, '9', 0));
-	Assert::false(Strings::after($foo, 'not-in-string'));
-	Assert::false(Strings::after($foo, 'b', -2));
-	Assert::false(Strings::after($foo, 'b', 2));
+	Assert::null(Strings::after($foo, '9', 0));
+	Assert::null(Strings::after($foo, 'not-in-string'));
+	Assert::null(Strings::after($foo, 'b', -2));
+	Assert::null(Strings::after($foo, 'b', 2));
 });
 
 

--- a/tests/Utils/Strings.before().phpt
+++ b/tests/Utils/Strings.before().phpt
@@ -26,10 +26,10 @@ test(function () {
 	Assert::same('0123456789a123456789b123456', Strings::before($foo, '789', 3));
 	Assert::same('012345678', Strings::before($foo, '9', -3));
 	Assert::same('0123456', Strings::before($foo, '789', -3));
-	Assert::false(Strings::before($foo, '9', 0));
-	Assert::false(Strings::before($foo, 'not-in-string'));
-	Assert::false(Strings::before($foo, 'b', -2));
-	Assert::false(Strings::before($foo, 'b', 2));
+	Assert::null(Strings::before($foo, '9', 0));
+	Assert::null(Strings::before($foo, 'not-in-string'));
+	Assert::null(Strings::before($foo, 'b', -2));
+	Assert::null(Strings::before($foo, 'b', 2));
 });
 
 

--- a/tests/Utils/Strings.indexOf().phpt
+++ b/tests/Utils/Strings.indexOf().phpt
@@ -27,10 +27,10 @@ test(function () {
 	Assert::same(27, Strings::indexOf($foo, '789', 3));
 	Assert::same(9, Strings::indexOf($foo, '9', -3));
 	Assert::same(7, Strings::indexOf($foo, '789', -3));
-	Assert::false(Strings::indexOf($foo, '9', 0));
-	Assert::false(Strings::indexOf($foo, 'not-in-string'));
-	Assert::false(Strings::indexOf($foo, 'b', -2));
-	Assert::false(Strings::indexOf($foo, 'b', 2));
+	Assert::null(Strings::indexOf($foo, '9', 0));
+	Assert::null(Strings::indexOf($foo, 'not-in-string'));
+	Assert::null(Strings::indexOf($foo, 'b', -2));
+	Assert::null(Strings::indexOf($foo, 'b', 2));
 });
 
 


### PR DESCRIPTION
- bug fix? no  
- BC break? yes

Returning FALSE on error is old way, not compatible with PHP 7.1 return type hints.