### PR TITLE
Destroy resource if Image is destroyed [WIP]

### DIFF
--- a/src/Utils/Image.php
+++ b/src/Utils/Image.php
@@ -219,7 +219,18 @@ class Image
 		imagesavealpha($image, TRUE);
 	}
 
+	
+	/**
+	 * Destroy image resource if any.
+	 */
+	public function __destruct()
+	{
+		if (is_resource($this->image)) {
+			imagedestroy($this->image);
+		}
+	}
 
+	
 	/**
 	 * Returns image width.
 	 */

--- a/src/Utils/Image.php
+++ b/src/Utils/Image.php
@@ -219,7 +219,7 @@ class Image
 		imagesavealpha($image, TRUE);
 	}
 
-	
+
 	/**
 	 * Destroy image resource if any.
 	 */
@@ -230,7 +230,7 @@ class Image
 		}
 	}
 
-	
+
 	/**
 	 * Returns image width.
 	 */


### PR DESCRIPTION
If you do not destroy image with imagedestroy, resource will be allocated for the rest of script life, this is problem in CLI scripts

- bug fix? yes
- new feature? no
- BC break? yes

This is mostly problem for CLI based scripts, that work with Nette\Utils\Images, if you save the image and unset variable, imagedestroy is not called and image stay in memory to the end of script life, it is fine if you load few images, but if you load more then few (10+) you can exhausted memory limit easily.