### PR TITLE
Filesystem::write() accept NULL in $mode parameter

### DIFF
--- a/src/Utils/FileSystem.php
+++ b/src/Utils/FileSystem.php
@@ -21,11 +21,10 @@ final class FileSystem
 
 	/**
 	 * Creates a directory.
-	 * @param  int|NULL $mode
 	 * @return void
 	 * @throws Nette\IOException
 	 */
-	public static function createDir(string $dir, $mode = 0777)
+	public static function createDir(string $dir, int $mode = 0777)
 	{
 		if (!is_dir($dir) && !@mkdir($dir, $mode, TRUE) && !is_dir($dir)) { // @ - dir may already exist
 			throw new Nette\IOException("Unable to create directory '$dir'. " . error_get_last()['message']);

--- a/src/Utils/FileSystem.php
+++ b/src/Utils/FileSystem.php
@@ -131,14 +131,12 @@ final class FileSystem
 
 	/**
 	 * Writes a string to a file.
-	 * @param $mode int|NULL
+	 * @param int|NULL $mode File creation mode
 	 * @return void
 	 * @throws Nette\IOException
 	 */
 	public static function write(string $file, string $content, $mode = 0666)
 	{
-		assert($mode === NULL || is_int($mode));
-
 		static::createDir(dirname($file));
 		if (@file_put_contents($file, $content) === FALSE) { // @ is escalated to exception
 			throw new Nette\IOException("Unable to write file '$file'.");

--- a/src/Utils/FileSystem.php
+++ b/src/Utils/FileSystem.php
@@ -131,7 +131,7 @@ final class FileSystem
 
 	/**
 	 * Writes a string to a file.
-	 * @param int|NULL $mode File creation mode
+	 * @param int|NULL $mode
 	 * @return void
 	 * @throws Nette\IOException
 	 */

--- a/src/Utils/FileSystem.php
+++ b/src/Utils/FileSystem.php
@@ -21,10 +21,11 @@ final class FileSystem
 
 	/**
 	 * Creates a directory.
+	 * @param  int|NULL $mode
 	 * @return void
 	 * @throws Nette\IOException
 	 */
-	public static function createDir(string $dir, int $mode = 0777)
+	public static function createDir(string $dir, $mode = 0777)
 	{
 		if (!is_dir($dir) && !@mkdir($dir, $mode, TRUE) && !is_dir($dir)) { // @ - dir may already exist
 			throw new Nette\IOException("Unable to create directory '$dir'. " . error_get_last()['message']);

--- a/src/Utils/FileSystem.php
+++ b/src/Utils/FileSystem.php
@@ -134,7 +134,7 @@ final class FileSystem
 	 * @return void
 	 * @throws Nette\IOException
 	 */
-	public static function write(string $file, string $content, int $mode = 0666)
+	public static function write(string $file, string $content, ?int $mode = 0666)
 	{
 		static::createDir(dirname($file));
 		if (@file_put_contents($file, $content) === FALSE) { // @ is escalated to exception

--- a/src/Utils/FileSystem.php
+++ b/src/Utils/FileSystem.php
@@ -131,11 +131,14 @@ final class FileSystem
 
 	/**
 	 * Writes a string to a file.
+	 * @param $mode int|NULL
 	 * @return void
 	 * @throws Nette\IOException
 	 */
-	public static function write(string $file, string $content, ?int $mode = 0666)
+	public static function write(string $file, string $content, $mode = 0666)
 	{
+		assert($mode === NULL || is_int($mode));
+
 		static::createDir(dirname($file));
 		if (@file_put_contents($file, $content) === FALSE) { // @ is escalated to exception
 			throw new Nette\IOException("Unable to write file '$file'.");

--- a/src/Utils/FileSystem.php
+++ b/src/Utils/FileSystem.php
@@ -131,7 +131,7 @@ final class FileSystem
 
 	/**
 	 * Writes a string to a file.
-	 * @param int|NULL $mode
+	 * @param  int|NULL $mode
 	 * @return void
 	 * @throws Nette\IOException
 	 */


### PR DESCRIPTION
- bug fix? yes
- new feature? no
- BC break? no (fixing unintended Nette 2.x BC break)

Code of function expects `$mode` to be `NULL`. If that happens it does not `chmod` it.