### PR TITLE
Ability to insert new item into array without specifying key

### DIFF
--- a/src/Utils/Arrays.php
+++ b/src/Utils/Arrays.php
@@ -94,7 +94,7 @@ class Arrays
 	public static function insertBefore(array &$arr, $key, array $inserted)
 	{
 		$offset = (int) self::searchKey($arr, $key);
-		$arr = array_slice($arr, 0, $offset, TRUE) + $inserted + array_slice($arr, $offset, count($arr), TRUE);
+		$arr = array_merge(array_slice($arr, 0, $offset, TRUE), $inserted, array_slice($arr, $offset, count($arr), TRUE));
 	}
 
 
@@ -106,7 +106,7 @@ class Arrays
 	{
 		$offset = self::searchKey($arr, $key);
 		$offset = $offset === NULL ? count($arr) : $offset + 1;
-		$arr = array_slice($arr, 0, $offset, TRUE) + $inserted + array_slice($arr, $offset, count($arr), TRUE);
+		$arr = array_merge(array_slice($arr, 0, $offset, TRUE), $inserted, array_slice($arr, $offset, count($arr), TRUE));
 	}
 
 


### PR DESCRIPTION
- bug fix? no   <!-- #issue numbers, if any -->
- new feature? yes
- BC break? yes

With this PR this is possible:
```php
$arr = [1,2,3];
Arrays::insertAfter($arr, 2, [4]);
```
instead of 
```php
$arr = [1,2,3];
Arrays::insertAfter($arr, 2, [3 => 4]);
```
