### PR TITLE
Mapper: supports count

### DIFF
--- a/src/Iterators/Mapper.php
+++ b/src/Iterators/Mapper.php
@@ -15,7 +15,7 @@ use Nette;
 /**
  * Applies the callback to the elements of the inner iterator.
  */
-class Mapper extends \IteratorIterator
+class Mapper extends \IteratorIterator implements \Countable
 {
 	/** @var callable */
 	private $callback;
@@ -32,5 +32,10 @@ class Mapper extends \IteratorIterator
 	{
 		return ($this->callback)(parent::current(), parent::key());
 	}
-
+	
+	
+	public function count()
+	{
+		return iterator_count($this->getInnerIterator());
+	}
 }

--- a/src/Iterators/Mapper.php
+++ b/src/Iterators/Mapper.php
@@ -32,8 +32,8 @@ class Mapper extends \IteratorIterator implements \Countable
 	{
 		return ($this->callback)(parent::current(), parent::key());
 	}
-	
-	
+
+
 	public function count()
 	{
 		return iterator_count($this->getInnerIterator());

--- a/tests/Iterators/Mapper.phpt
+++ b/tests/Iterators/Mapper.phpt
@@ -34,3 +34,5 @@ assert::same('David: Grudl', $iterator->current());
 
 $iterator->next();
 Assert::false($iterator->valid());
+
+Assert::count(2, $iterator);


### PR DESCRIPTION
- bug fix? no
- new feature? yes
- BC break? no

Now `count($mapper)` returns always `1` and no error is triggered (until 7.2.0).
https://3v4l.org/56k0a

Current workaround is to use the code from `count` method.

I can add iterator_count to CachingIterator too... Or if this behavior is intended then I can copy it to Mapper to support it this way.