### PR TITLE
FileSystem::rename() fix renaming file/directory if only case changes

### DIFF
--- a/src/Utils/FileSystem.php
+++ b/src/Utils/FileSystem.php
@@ -107,7 +107,7 @@ final class FileSystem
 
 		} else {
 			static::createDir(dirname($newName));
-			if (Strings::lower(realpath($name)) !== Strings::lower(realpath($newName))) {
+			if (realpath($name) !== realpath($newName)) {
 				static::delete($newName);
 			}
 			if (!@rename($name, $newName)) { // @ is escalated to exception

--- a/src/Utils/FileSystem.php
+++ b/src/Utils/FileSystem.php
@@ -107,7 +107,7 @@ final class FileSystem
 
 		} else {
 			static::createDir(dirname($newName));
-			if (Strings::lower($name) !== Strings::lower($newName)) {
+			if (Strings::lower(realpath($name)) !== Strings::lower(realpath($newName))) {
 				static::delete($newName);
 			}
 			if (!@rename($name, $newName)) { // @ is escalated to exception

--- a/src/Utils/FileSystem.php
+++ b/src/Utils/FileSystem.php
@@ -107,7 +107,9 @@ final class FileSystem
 
 		} else {
 			static::createDir(dirname($newName));
-			static::delete($newName);
+			if (Strings::lower($name) !== Strings::lower($newName)) {
+				static::delete($newName);
+			}
 			if (!@rename($name, $newName)) { // @ is escalated to exception
 				throw new Nette\IOException("Unable to rename file or directory '$name' to '$newName'.");
 			}


### PR DESCRIPTION
- bug fix? yes
- new feature? no
- BC break? no

When trying to rename file/directory itself in order to change only case of filename (eg. `test.php` to `Test.php`), the process fails as the method first [deletes](https://github.com/nette/utils/blob/master/src/Utils/FileSystem.php#L110) the desired file(name) prior to renaming it .. thus it deletes the original file/dir that was about to be renamed.
This change prevents that case.

<!--
Describe your changes here to communicate to the maintainers why we should accept this pull request.

Please add new tests to show the fix or feature works. And take a moment to read the contributing guide https://nette.org/en/contributing

Thanks for contributing to Nette!
-->
