### PR TITLE
Fix typo in exception message

### DIFF
--- a/src/Utils/Random.php
+++ b/src/Utils/Random.php
@@ -32,7 +32,7 @@ final class Random
 		if ($length < 1) {
 			throw new Nette\InvalidArgumentException('Length must be greater than zero.');
 		} elseif ($chLen < 2) {
-			throw new Nette\InvalidArgumentException('Character list must contain as least two chars.');
+			throw new Nette\InvalidArgumentException('Character list must contain at least two chars.');
 		}
 
 		$res = '';

--- a/tests/Utils/Random.generate().phpt
+++ b/tests/Utils/Random.generate().phpt
@@ -28,7 +28,7 @@ Assert::exception(function () {
 
 Assert::exception(function () {
 	Random::generate(1, '000');
-}, Nette\InvalidArgumentException::class, 'Character list must contain as least two chars.');
+}, Nette\InvalidArgumentException::class, 'Character list must contain at least two chars.');
 
 
 // frequency check


### PR DESCRIPTION
- bug fix? no
- new feature? no
- BC break? no

Fix a typo in an exception message thrown when character list contains less than two chars.