### PR TITLE
Added removeAttributes method - removing multiple attributes

### DIFF
--- a/src/Utils/Html.php
+++ b/src/Utils/Html.php
@@ -177,6 +177,20 @@ class Html implements \ArrayAccess, \Countable, \IteratorAggregate, IHtmlString
 
 
 	/**
+	 * Unsets element's attributes.
+	 * @return static
+	 */
+	public function removeAttributes(array $attributes)
+	{
+		foreach ($attributes as $attribute) {
+			$this->removeAttribute($attribute);
+		}
+
+		return $this;
+	}
+
+
+	/**
 	 * Overloaded setter for element's attribute.
 	 * @return void
 	 */
@@ -569,7 +583,7 @@ class Html implements \ArrayAccess, \Countable, \IteratorAggregate, IHtmlString
 					$tmp = null;
 					foreach ($value as $k => $v) {
 						if ($v != null) { // intentionally ==, skip nulls & empty string
-							//  composite 'style' vs. 'others'
+							// composite 'style' vs. 'others'
 							$tmp[] = $v === true ? $k : (is_string($k) ? $k . ':' . $v : $v);
 						}
 					}

--- a/tests/Utils/Html.basic.phpt
+++ b/tests/Utils/Html.basic.phpt
@@ -177,3 +177,14 @@ test(function () { // isset
 	Assert::true(isset(Html::el('a')->setAttribute('id', '')->id));
 	Assert::false(isset(Html::el('a')->setAttribute('id', null)->id));
 });
+
+
+test(function () { // isset
+	$el = Html::el('a')->addAttributes(['onclick' => '', 'onmouseover' => '']);
+	Assert::true(isset($el->onclick));
+	Assert::true(isset($el->onmouseover));
+
+	$el->removeAttributes(['onclick', 'onmouseover']);
+	Assert::false(isset($el->onclick));
+	Assert::false(isset($el->onmouseover));
+});


### PR DESCRIPTION
- bug fix? no 
- new feature? yes

**Description**
- Added method removeAttributes for removing multiple attributes
- Why: for example when converting html element to the Amp html element, sometimes is necessary to remove multiple (by Amp disabled) attributes like frameborder, allowfullscreen or scrolling
- There is already a method for setting multiple attributes but non for removing multiple attributes so it means to create loops in order to remove them