### PR TITLE
Properties Image::image and Image::formats as protected for able to extensions

### DIFF
--- a/src/Utils/Image.php
+++ b/src/Utils/Image.php
@@ -115,10 +115,10 @@ class Image
 
 	const EMPTY_GIF = "GIF89a\x01\x00\x01\x00\x80\x00\x00\x00\x00\x00\x00\x00\x00!\xf9\x04\x01\x00\x00\x00\x00,\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x02D\x01\x00;";
 
-	private static $formats = [self::JPEG => 'jpeg', self::PNG => 'png', self::GIF => 'gif', self::WEBP => 'webp'];
+	protected static $formats = [self::JPEG => 'jpeg', self::PNG => 'png', self::GIF => 'gif', self::WEBP => 'webp'];
 
 	/** @var resource */
-	private $image;
+	protected $image;
 
 
 	/**


### PR DESCRIPTION
- bug fix? no   
- new feature? yes 
- BC break? no
- doc PR: not necessary

I change protection of properties (Image::image and Image::format) from private to protected for able to extensions.
