### PR TITLE
Used native PHP function for image types

### DIFF
--- a/src/Utils/Image.php
+++ b/src/Utils/Image.php
@@ -152,7 +152,7 @@ class Image
 			$detectedFormat = null;
 			throw new UnknownImageFileException(is_file($file) ? "Unknown type of file '$file'." : "File '$file' not found.");
 		}
-		return new static(Callback::invokeSafe('imagecreatefrom' . self::$formats[$detectedFormat], [$file], function (string $message) {
+		return new static(Callback::invokeSafe('imagecreatefrom' . image_type_to_extension($detectedFormat,FALSE), [$file], function (string $message) {
 			throw new ImageException($message);
 		}));
 	}
@@ -560,7 +560,7 @@ class Image
 		if (!isset(self::$formats[$type])) {
 			throw new Nette\InvalidArgumentException("Unsupported image type '$type'.");
 		}
-		header('Content-Type: image/' . self::$formats[$type]);
+		header('Content-Type: ' . image_type_to_mime_type($type));
 		$this->save(null, $quality, $type);
 	}
 


### PR DESCRIPTION
Used `image_type_to_extension` and `image_type_to_mime_type`

- bug fix? no
- new feature? no
- BC break? no

I think it's better to use native functions instead of work with arrays.
http://php.net/manual/en/function.image-type-to-mime-type.php
http://php.net/manual/en/function.image-type-to-extension.php
