### PR TITLE
Image: throw exception when $file and $type is null

### DIFF
--- a/src/Utils/Image.php
+++ b/src/Utils/Image.php
@@ -483,6 +483,10 @@ class Image
 	 */
 	public function save(string $file = null, int $quality = null, int $type = null): void
 	{
+		if ($type === null && $file === null) {
+			throw new Nette\InvalidArgumentException('Either the output file or type must be set.');
+		}
+
 		if ($type === null) {
 			$extensions = array_flip(self::$formats) + ['jpg' => self::JPEG];
 			$ext = strtolower(pathinfo($file, PATHINFO_EXTENSION));

--- a/tests/Utils/Image.save.phpt
+++ b/tests/Utils/Image.save.phpt
@@ -46,6 +46,11 @@ test(function () use ($main) {
 });
 
 
+Assert::exception(function () use ($main) {
+	$main->save();
+}, Nette\InvalidArgumentException::class, 'Either the output file or type must be set.');
+
+
 Assert::exception(function () use ($main) { // invalid image type
 	$main->save('foo', null, IMG_WBMP);
 }, Nette\InvalidArgumentException::class, sprintf('Unsupported image type \'%d\'.', IMG_WBMP));


### PR DESCRIPTION
Fixes problem with calling 'pathinfo()' with null filename.

- bug fix? yes
- BC break? no