### PR TITLE
Adds the plus character as a valid option in numeric strings

### DIFF
--- a/src/Utils/Validators.php
+++ b/src/Utils/Validators.php
@@ -178,7 +178,7 @@ class Validators
 	 */
 	public static function isNumericInt($value): bool
 	{
-		return is_int($value) || is_string($value) && preg_match('#^-?[0-9]+\z#', $value);
+		return is_int($value) || is_string($value) && preg_match('#^[+-]?[0-9]+\z#', $value);
 	}
 
 
@@ -187,7 +187,7 @@ class Validators
 	 */
 	public static function isNumeric($value): bool
 	{
-		return is_float($value) || is_int($value) || is_string($value) && preg_match('#^-?[0-9]*[.]?[0-9]+\z#', $value);
+		return is_float($value) || is_int($value) || is_string($value) && preg_match('#^[+-]?[0-9]*[.]?[0-9]+\z#', $value);
 	}
 
 

--- a/tests/Utils/Validators.is().phpt
+++ b/tests/Utils/Validators.is().phpt
@@ -55,6 +55,9 @@ test(function () {
 	Assert::true(Validators::is('-1', 'numeric'));
 	Assert::true(Validators::is('-1.5', 'numeric'));
 	Assert::true(Validators::is('-.5', 'numeric'));
+	Assert::true(Validators::is('+1', 'numeric'));
+	Assert::true(Validators::is('+1.5', 'numeric'));
+	Assert::true(Validators::is('+.5', 'numeric'));
 	Assert::false(Validators::is('1e6', 'numeric'));
 	Assert::true(Validators::is(1, 'numeric'));
 	Assert::true(Validators::is(1.0, 'numeric'));
@@ -67,6 +70,9 @@ test(function () {
 	Assert::true(Validators::is('-1', 'numericint'));
 	Assert::false(Validators::is('-1.5', 'numericint'));
 	Assert::false(Validators::is('-.5', 'numericint'));
+	Assert::true(Validators::is('+1', 'numericint'));
+	Assert::false(Validators::is('+1.5', 'numericint'));
+	Assert::false(Validators::is('+.5', 'numericint'));
 	Assert::false(Validators::is('1e6', 'numericint'));
 	Assert::true(Validators::is(1, 'numericint'));
 	Assert::false(Validators::is(1.0, 'numericint'));


### PR DESCRIPTION
- bug fix? no
- new feature? yes
- BC break? no
- doc PR: n/a

For whatever reason numeric strings with explicitly positive values (i.e. `+1` instead of just `1`) have not been considered as valid numerics even though they are perfectly valid (in the sense that even forcibly changing their type to the respective numeric type works as expected).

This PR fixes that issue, adding consistency with PHP and the way numbers can be written to the Validator class.

I have marked this as "not bc breaking" because (1) this use case has not been covered by tests, so it doesn't change any and (2) nobody should accept `'-1'` as a valid value and expect `'+1'` to fail.

Please merge this with squash; I accidentally made one too many commits.