### PR TITLE
 Require tokenizer extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
 	],
 	"require": {
 		"php": ">=7.1"
+		"ext-tokenizer": "to use token_get_all()"
 	},
 	"require-dev": {
 		"nette/tester": "~2.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		}
 	],
 	"require": {
-		"php": ">=7.1"
+		"php": ">=7.1",
 		"ext-tokenizer": "to use token_get_all()"
 	},
 	"require-dev": {


### PR DESCRIPTION
- bug fix
- BC break? no

We cannot run (e.g. `php -n phpstan analyze`) with Debian's default PHP binary. tokenizer.so is part of php7.2-common which is a dependency but any custom PHP build may lack it.