### PR TITLE
More verbose Json::decodeToObject and Json::decodeToArray methods

### DIFF
--- a/src/Utils/Json.php
+++ b/src/Utils/Json.php
@@ -54,4 +54,24 @@ final class Json
 		}
 		return $value;
 	}
+
+
+	/**
+	 * Decodes a JSON string to a stdClass
+	 * @return \stdClass
+	 */
+	public static function decodeToObject(string $json)
+	{
+		return (object) self::decode($json);
+	}
+
+
+	/**
+	 * Decodes a JSON string to an array
+	 * @return mixed[]
+	 */
+	public static function decodeToArray(string $json)
+	{
+		return self::decode($json, self::FORCE_ARRAY);
+	}
 }

--- a/tests/Utils/Json.decodeToArray().phpt
+++ b/tests/Utils/Json.decodeToArray().phpt
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * Test: Nette\Utils\Json::decode()
+ */
+
+declare(strict_types=1);
+
+use Nette\Utils\Json;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+Assert::same(['a' => 1], Json::decodeToArray('{"a":1}'));

--- a/tests/Utils/Json.decodeToObject().phpt
+++ b/tests/Utils/Json.decodeToObject().phpt
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Test: Nette\Utils\Json::decode()
+ */
+
+declare(strict_types=1);
+
+use Nette\Utils\Json;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+Assert::equal((object) ['a' => 1], Json::decodeToObject('{"a":1}'));
+Assert::equal((object) ['a', 'b'], Json::decodeToObject('["a","b"]'));


### PR DESCRIPTION
- new feature
- No BC break
- doc PR: https://github.com/nette/docs/pull/760

Introduces Json::decodeToObject and Json::decodeToArray methods for clearer code intent and error avoidance.