### PR TITLE
Fix incorrect time zone when using DateTime() constructor

### DIFF
--- a/src/Utils/DateTime.php
+++ b/src/Utils/DateTime.php
@@ -33,6 +33,12 @@ class DateTime extends \DateTime
 	/** average year in seconds */
 	const YEAR = 31557600;
 
+	public function __construct($time = "now", $timezone = NULL) {
+		if ($timezone === NULL) {
+			$timezone = new \DateTimeZone(date_default_timezone_get());
+		}
+		parent::__construct($time, $timezone);
+	}
 
 	/**
 	 * DateTime object factory.


### PR DESCRIPTION
- bug fix
- BC break? no

DateTime fixes in Nette do not protect the __constructor against using incorrect timezone. This pull request fixes that.
