### PR TITLE
Add __toString() return statement + __sleep() return type.

### DIFF
--- a/src/Utils/Image.php
+++ b/src/Utils/Image.php
@@ -519,6 +519,7 @@ class Image
 				throw $e;
 			}
 			trigger_error('Exception in ' . __METHOD__ . "(): {$e->getMessage()} in {$e->getFile()}:{$e->getLine()}", E_USER_ERROR);
+			return '';
 		}
 	}
 
@@ -614,7 +615,7 @@ class Image
 	/**
 	 * Prevents serialization.
 	 */
-	public function __sleep()
+	public function __sleep(): array
 	{
 		throw new Nette\NotSupportedException('You cannot serialize or unserialize ' . self::class . ' instances.');
 	}

--- a/tests/Utils/Image.toString.phpt
+++ b/tests/Utils/Image.toString.phpt
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Test: Nette\Utils\Image save method exceptions.
+ * @phpExtension gd
+ */
+
+declare(strict_types=1);
+
+use Nette\Utils\Image;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+$main = Image::fromFile(__DIR__ . '/fixtures.images/alpha1.png');
+
+
+test(function () use ($main) {
+	Assert::true(is_string((string) $main));
+});


### PR DESCRIPTION
- new feature
- BC break? no

Changed:

- `__sleep` must return array. Documentation: https://www.php.net/manual/en/language.oop5.magic.php#object.sleep
- `__toString` missing return statement.
