### PR TITLE
FileSystem: copy: Add binary safe parameter

### DIFF
--- a/src/Utils/FileSystem.php
+++ b/src/Utils/FileSystem.php
@@ -58,7 +58,7 @@ final class FileSystem
 
 		} else {
 			static::createDir(dirname($dest));
-			if (($s = @fopen($source, 'r')) && ($d = @fopen($dest, 'w')) && @stream_copy_to_stream($s, $d) === false) { // @ is escalated to exception
+			if (($s = @fopen($source, 'rb')) && ($d = @fopen($dest, 'wb')) && @stream_copy_to_stream($s, $d) === false) { // @ is escalated to exception
 				throw new Nette\IOException("Unable to copy file '$source' to '$dest'. " . self::getLastError());
 			}
 		}


### PR DESCRIPTION
- new feature
- BC break? yes

`copy`: The mode is not binary-safe ('b' is missing).