### PR TITLE
Strings: throw exception on malformed UTF-8 in webalize() and toAscii()

### DIFF
--- a/src/Utils/Strings.php
+++ b/src/Utils/Strings.php
@@ -142,7 +142,7 @@ class Strings
 			$transliterator = \Transliterator::create('Any-Latin; Latin-ASCII');
 		}
 
-		$s = preg_replace('#[^\x09\x0A\x0D\x20-\x7E\xA0-\x{2FF}\x{370}-\x{10FFFF}]#u', '', $s);
+		$s = self::pcre('preg_replace', ['#[^\x09\x0A\x0D\x20-\x7E\xA0-\x{2FF}\x{370}-\x{10FFFF}]#u', '', $s]);
 		$s = strtr($s, '`\'"^~?', "\x01\x02\x03\x04\x05\x06");
 		$s = str_replace(
 			["\u{201E}", "\u{201C}", "\u{201D}", "\u{201A}", "\u{2018}", "\u{2019}", "\u{B0}"],

--- a/tests/Utils/Strings.toAscii().phpt
+++ b/tests/Utils/Strings.toAscii().phpt
@@ -21,6 +21,9 @@ Assert::same('', Strings::toAscii("\u{10000}")); // U+10000
 Assert::same('', Strings::toAscii("\u{A4}")); // non-ASCII char
 Assert::same('a b', Strings::toAscii("a\u{A0}b")); // non-breaking space
 Assert::same('Tarikh', Strings::toAscii("Ta\u{2BE}rikh")); // Taʾrikh
+Assert::exception(function () {
+	Strings::toAscii("0123456789\xFF");
+}, Nette\Utils\RegexpException::class, null, PREG_BAD_UTF8_ERROR);
 
 if (class_exists('Transliterator') && \Transliterator::create('Any-Latin; Latin-ASCII')) {
 	Assert::same('Athena->Moskva', Strings::toAscii("\u{391}\u{3B8}\u{3AE}\u{3BD}\u{3B1}\u{2192}\u{41C}\u{43E}\u{441}\u{43A}\u{432}\u{430}")); // Αθήνα→Москва

--- a/tests/Utils/Strings.webalize().phpt
+++ b/tests/Utils/Strings.webalize().phpt
@@ -17,3 +17,6 @@ Assert::same('zlutoucky-kun-oooo', Strings::webalize("&\u{17D}LU\u{164}OU\u{10C}
 Assert::same('ZLUTOUCKY-KUN-oooo', Strings::webalize("&\u{17D}LU\u{164}OU\u{10C}K\u{DD} K\u{16E}\u{147} \u{F6}\u{151}\u{F4}o!", null, false)); // &ŽLUŤOUČKÝ KŮŇ öőôo!
 Assert::same('1-4-!', Strings::webalize("\u{BC} !", '!'));
 Assert::same('a-b', Strings::webalize("a\u{A0}b")); // non-breaking space
+Assert::exception(function () {
+	Strings::toAscii("0123456789\xFF");
+}, Nette\Utils\RegexpException::class, null, PREG_BAD_UTF8_ERROR);


### PR DESCRIPTION
- bug fix
- BC break? no

Since `Strings::webalize()` can be called on user input it should be able to deal with anything or error in a predicable way. But when an malformed UTF-8 input is given currently it results in:

```
Nette\Utils\RegexpException was expected but got TypeError (strtr() expects parameter 1 to be string, null given)
```

(i guess this behaved differently before scrict types were added in [3.0.0](https://github.com/nette/utils/releases/tag/v3.0.0)).

Throwing an exception (the same exception as in other cases such as `Strings::replace()`) seems reasonable to me.

I am also not sure why the internal handling of PCRE is not used everywhere in calling `preg_*` is not used everywhere in the file, because there might be of course other problems too?
