### PR TITLE
Strings: Fix boolean return of Normalizer.

### DIFF
--- a/src/Utils/Strings.php
+++ b/src/Utils/Strings.php
@@ -104,8 +104,8 @@ class Strings
 	public static function normalize(string $s): string
 	{
 		// convert to compressed normal form (NFC)
-		if (class_exists('Normalizer', false)) {
-			$s = \Normalizer::normalize($s, \Normalizer::FORM_C);
+		if (class_exists('Normalizer', false) && ($n = \Normalizer::normalize($s, \Normalizer::FORM_C)) !== false) {
+			$s = $n;
 		}
 
 		$s = self::normalizeNewLines($s);


### PR DESCRIPTION
- bug fix
- BC break? yes

In case of `Strings::normalize("... \xbee m\xc3\xa1\xc5\xa1 ...");` normalizer throw error, because `\Normalizer::normalize` can return `false` in case of invalid string.

Now normalized string will be used only in case of valid return. In other cases keep original.

<img width="1108" alt="Snímek obrazovky 2019-12-16 v 14 31 24" src="https://user-images.githubusercontent.com/4738758/70911276-d6e3af00-2011-11ea-83d0-6fba89f0f564.png">

Thanks.