### PR TITLE
Normalizer: Add support for fix malformedData

### DIFF
--- a/.github/workflows/coding-style.yml
+++ b/.github/workflows/coding-style.yml
@@ -1,0 +1,31 @@
+name: Coding Style
+
+on: [push, pull_request]
+
+jobs:
+    nette_cc:
+        name: Nette Code Checker
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: shivammathur/setup-php@v1
+              with:
+                  php-version: 7.4
+                  coverage: none
+
+            - run: composer create-project nette/code-checker temp/code-checker ^3 --no-progress
+            - run: php temp/code-checker/code-checker --strict-types --no-progress -i tests/Utils/fixtures.reflection
+
+
+    nette_cs:
+        name: Nette Coding Standard
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: shivammathur/setup-php@v1
+              with:
+                  php-version: 7.4
+                  coverage: none
+
+            - run: composer create-project nette/coding-standard temp/coding-standard ^2 --no-progress
+            - run: php temp/coding-standard/ecs check src tests --config tests/coding-standard.yml

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,21 @@
+name: Static Analysis (only informative)
+
+on:
+    push:
+        branches:
+          - master
+
+jobs:
+    phpstan:
+        name: PHPStan
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: shivammathur/setup-php@v1
+              with:
+                  php-version: 7.4
+                  coverage: none
+
+            - run: composer install --no-progress --prefer-dist
+            - run: composer phpstan
+              continue-on-error: true # is only informative

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,47 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+    tests:
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                os: [ubuntu-latest, windows-latest, macOS-latest]
+                php: ['7.1', '7.2', '7.3', '7.4']
+
+            fail-fast: false
+
+        name: PHP ${{ matrix.php }} tests on ${{ matrix.os }}
+        steps:
+            - uses: actions/checkout@v2
+            - uses: shivammathur/setup-php@v1
+              with:
+                  php-version: ${{ matrix.php }}
+                  extensions: iconv, json, mbstring, xml, gd, intl, tokenizer
+                  coverage: none
+
+            - run: composer install --no-progress --prefer-dist
+            - run: vendor/bin/tester tests -s -C
+            - if: failure()
+              uses: actions/upload-artifact@v1
+              with:
+                  name: output
+                  path: tests/Utils/output
+
+
+    code_coverage:
+        name: Code Coverage
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: shivammathur/setup-php@v1
+              with:
+                  php-version: 7.4
+                  extensions: iconv, json, mbstring, xml, gd, intl, tokenizer
+                  coverage: none
+
+            - run: composer install --no-progress --prefer-dist
+            - run: wget https://github.com/satooshi/php-coveralls/releases/download/v1.0.1/coveralls.phar
+            - run: vendor/bin/tester -p phpdbg tests -s -C --coverage ./coverage.xml --coverage-src ./src
+            - run: php coveralls.phar --verbose --config tests/.coveralls.yml

--- a/src/Utils/ArrayHash.php
+++ b/src/Utils/ArrayHash.php
@@ -17,10 +17,7 @@ use Nette;
  */
 class ArrayHash extends \stdClass implements \ArrayAccess, \Countable, \IteratorAggregate
 {
-
-	/**
-	 * @return static
-	 */
+	/** @return static */
 	public static function from(array $arr, bool $recursive = true)
 	{
 		$obj = new static;

--- a/src/Utils/ArrayHash.php
+++ b/src/Utils/ArrayHash.php
@@ -55,6 +55,8 @@ class ArrayHash extends \stdClass implements \ArrayAccess, \Countable, \Iterator
 
 	/**
 	 * Replaces or appends a item.
+	 * @param  string|int  $key
+	 * @param  mixed  $value
 	 */
 	public function offsetSet($key, $value): void
 	{
@@ -67,6 +69,7 @@ class ArrayHash extends \stdClass implements \ArrayAccess, \Countable, \Iterator
 
 	/**
 	 * Returns a item.
+	 * @param  string|int  $key
 	 * @return mixed
 	 */
 	public function offsetGet($key)
@@ -77,6 +80,7 @@ class ArrayHash extends \stdClass implements \ArrayAccess, \Countable, \Iterator
 
 	/**
 	 * Determines whether a item exists.
+	 * @param  string|int  $key
 	 */
 	public function offsetExists($key): bool
 	{
@@ -86,6 +90,7 @@ class ArrayHash extends \stdClass implements \ArrayAccess, \Countable, \Iterator
 
 	/**
 	 * Removes the element from this list.
+	 * @param  string|int  $key
 	 */
 	public function offsetUnset($key): void
 	{

--- a/src/Utils/ArrayList.php
+++ b/src/Utils/ArrayList.php
@@ -19,6 +19,7 @@ class ArrayList implements \ArrayAccess, \Countable, \IteratorAggregate
 {
 	use Nette\SmartObject;
 
+	/** @var mixed[] */
 	private $list = [];
 
 
@@ -43,6 +44,7 @@ class ArrayList implements \ArrayAccess, \Countable, \IteratorAggregate
 	/**
 	 * Replaces or appends a item.
 	 * @param  int|null  $index
+	 * @param  mixed  $value
 	 * @throws Nette\OutOfRangeException
 	 */
 	public function offsetSet($index, $value): void
@@ -100,6 +102,7 @@ class ArrayList implements \ArrayAccess, \Countable, \IteratorAggregate
 
 	/**
 	 * Prepends a item.
+	 * @param  mixed  $value
 	 */
 	public function prepend($value): void
 	{

--- a/src/Utils/Arrays.php
+++ b/src/Utils/Arrays.php
@@ -23,6 +23,7 @@ class Arrays
 	/**
 	 * Returns item from array or $default if item is not set.
 	 * @param  string|int|array $key one or more keys
+	 * @param  mixed  $default
 	 * @return mixed
 	 * @throws Nette\InvalidArgumentException if item does not exist and default value is not provided
 	 */
@@ -78,6 +79,7 @@ class Arrays
 
 	/**
 	 * Searches the array for a given key and returns the offset if successful.
+	 * @param  string|int  $key
 	 * @return int|null offset if it is found, null otherwise
 	 */
 	public static function searchKey(array $arr, $key): ?int
@@ -89,6 +91,7 @@ class Arrays
 
 	/**
 	 * Inserts new array before item specified by key.
+	 * @param  string|int  $key
 	 */
 	public static function insertBefore(array &$arr, $key, array $inserted): void
 	{
@@ -99,6 +102,7 @@ class Arrays
 
 	/**
 	 * Inserts new array after item specified by key.
+	 * @param  string|int  $key
 	 */
 	public static function insertAfter(array &$arr, $key, array $inserted): void
 	{
@@ -110,6 +114,8 @@ class Arrays
 
 	/**
 	 * Renames key in array.
+	 * @param  string|int  $oldKey
+	 * @param  string|int  $newKey
 	 */
 	public static function renameKey(array &$arr, $oldKey, $newKey): void
 	{
@@ -147,6 +153,7 @@ class Arrays
 
 	/**
 	 * Finds whether a variable is a zero-based integer indexed array.
+	 * @param  mixed  $value
 	 */
 	public static function isList($value): bool
 	{
@@ -156,6 +163,7 @@ class Arrays
 
 	/**
 	 * Reformats table to associative tree. Path looks like 'field|field[]field->field=field'.
+	 * @param  string|string[]  $path
 	 * @return array|\stdClass
 	 */
 	public static function associate(array $arr, $path)
@@ -211,6 +219,7 @@ class Arrays
 
 	/**
 	 * Normalizes to associative array.
+	 * @param  mixed  $filling
 	 */
 	public static function normalize(array $arr, $filling = null): array
 	{
@@ -224,7 +233,8 @@ class Arrays
 
 	/**
 	 * Picks element from the array by key and return its value.
-	 * @param  string|int $key array key
+	 * @param  string|int  $key
+	 * @param  mixed  $default
 	 * @return mixed
 	 * @throws Nette\InvalidArgumentException if item does not exist and default value is not provided
 	 */

--- a/src/Utils/Callback.php
+++ b/src/Utils/Callback.php
@@ -86,6 +86,7 @@ final class Callback
 
 
 	/**
+	 * @param  mixed  $callable
 	 * @return callable
 	 */
 	public static function check($callable, bool $syntax = false)
@@ -100,6 +101,9 @@ final class Callback
 	}
 
 
+	/**
+	 * @param  mixed  $callable  may be syntactically correct but not callable
+	 */
 	public static function toString($callable): string
 	{
 		if ($callable instanceof \Closure) {
@@ -114,6 +118,9 @@ final class Callback
 	}
 
 
+	/**
+	 * @param  callable  $callable  is escalated to ReflectionException
+	 */
 	public static function toReflection($callable): \ReflectionFunctionAbstract
 	{
 		if ($callable instanceof \Closure) {

--- a/src/Utils/DateTime.php
+++ b/src/Utils/DateTime.php
@@ -113,9 +113,7 @@ class DateTime extends \DateTime implements \JsonSerializable
 	}
 
 
-	/**
-	 * @return static
-	 */
+	/** @return static */
 	public function modifyClone(string $modify = '')
 	{
 		$dolly = clone $this;

--- a/src/Utils/Helpers.php
+++ b/src/Utils/Helpers.php
@@ -42,6 +42,8 @@ class Helpers
 
 	/**
 	 * Converts false to null.
+	 * @param  mixed  $val
+	 * @return mixed
 	 */
 	public static function falseToNull($val)
 	{

--- a/src/Utils/Html.php
+++ b/src/Utils/Html.php
@@ -234,20 +234,20 @@ class Html implements \ArrayAccess, \Countable, \IteratorAggregate, IHtmlString
 {
 	use Nette\SmartObject;
 
-	/** @var array  element's attributes */
+	/** @var array<string, mixed>  element's attributes */
 	public $attrs = [];
 
 	/** @var bool  use XHTML syntax? */
 	public static $xhtml = false;
 
-	/** @var array  empty (void) elements */
+	/** @var array<string, int>  void elements */
 	public static $emptyElements = [
 		'img' => 1, 'hr' => 1, 'br' => 1, 'input' => 1, 'meta' => 1, 'area' => 1, 'embed' => 1, 'keygen' => 1,
 		'source' => 1, 'base' => 1, 'col' => 1, 'link' => 1, 'param' => 1, 'basefont' => 1, 'frame' => 1,
 		'isindex' => 1, 'wbr' => 1, 'command' => 1, 'track' => 1,
 	];
 
-	/** @var array  of Html | string nodes */
+	/** @var array<int, Html|string> nodes */
 	protected $children = [];
 
 	/** @var string  element's name */
@@ -373,6 +373,8 @@ class Html implements \ArrayAccess, \Countable, \IteratorAggregate, IHtmlString
 
 	/**
 	 * Appends value to element's attribute.
+	 * @param  mixed  $value
+	 * @param  mixed  $option
 	 * @return static
 	 */
 	public function appendAttribute(string $name, $value, $option = true)
@@ -396,6 +398,7 @@ class Html implements \ArrayAccess, \Countable, \IteratorAggregate, IHtmlString
 
 	/**
 	 * Sets element's attribute.
+	 * @param  mixed  $value
 	 * @return static
 	 */
 	public function setAttribute(string $name, $value)
@@ -441,6 +444,7 @@ class Html implements \ArrayAccess, \Countable, \IteratorAggregate, IHtmlString
 
 	/**
 	 * Overloaded setter for element's attribute.
+	 * @param  mixed  $value
 	 */
 	final public function __set(string $name, $value): void
 	{
@@ -526,6 +530,7 @@ class Html implements \ArrayAccess, \Countable, \IteratorAggregate, IHtmlString
 
 	/**
 	 * Setter for data-* attributes. Booleans are converted to 'true' resp. 'false'.
+	 * @param  mixed  $value
 	 * @return static
 	 */
 	public function data(string $name, $value = null)

--- a/src/Utils/IHtmlString.php
+++ b/src/Utils/IHtmlString.php
@@ -12,7 +12,6 @@ namespace Nette\Utils;
 
 interface IHtmlString
 {
-
 	/**
 	 * Returns string in HTML format
 	 */

--- a/src/Utils/ITranslator.php
+++ b/src/Utils/ITranslator.php
@@ -18,6 +18,8 @@ interface ITranslator
 
 	/**
 	 * Translates the given string.
+	 * @param  mixed  $message
+	 * @param  mixed  ...$parameters
 	 */
 	function translate($message, ...$parameters): string;
 }

--- a/src/Utils/ITranslator.php
+++ b/src/Utils/ITranslator.php
@@ -15,7 +15,6 @@ namespace Nette\Localization;
  */
 interface ITranslator
 {
-
 	/**
 	 * Translates the given string.
 	 * @param  mixed  $message

--- a/src/Utils/Image.php
+++ b/src/Utils/Image.php
@@ -211,6 +211,21 @@ class Image
 	}
 
 
+	public static function typeToExtension(int $type): string
+	{
+		if (!isset(self::FORMATS[$type])) {
+			throw new Nette\InvalidArgumentException("Unsupported image type '$type'.");
+		}
+		return self::FORMATS[$type];
+	}
+
+
+	public static function typeToMimeType(int $type): string
+	{
+		return 'image/' . self::typeToExtension($type);
+	}
+
+
 	/**
 	 * Wraps GD image.
 	 * @param  resource  $image
@@ -542,10 +557,7 @@ class Image
 	 */
 	public function send(int $type = self::JPEG, int $quality = null): void
 	{
-		if (!isset(self::FORMATS[$type])) {
-			throw new Nette\InvalidArgumentException("Unsupported image type '$type'.");
-		}
-		header('Content-Type: ' . image_type_to_mime_type($type));
+		header('Content-Type: ' . self::typeToMimeType($type));
 		$this->output($type, $quality);
 	}
 

--- a/src/Utils/Json.php
+++ b/src/Utils/Json.php
@@ -28,6 +28,7 @@ final class Json
 
 	/**
 	 * Returns the JSON representation of a value. Accepts flag Json::PRETTY.
+	 * @param  mixed  $value
 	 * @throws JsonException
 	 */
 	public static function encode($value, int $flags = 0): string

--- a/src/Utils/Json.php
+++ b/src/Utils/Json.php
@@ -28,6 +28,7 @@ final class Json
 
 	/**
 	 * Returns the JSON representation of a value. Accepts flag Json::PRETTY.
+	 * @throws JsonException
 	 */
 	public static function encode($value, int $flags = 0): string
 	{
@@ -47,6 +48,7 @@ final class Json
 	/**
 	 * Decodes a JSON string. Accepts flag Json::FORCE_ARRAY.
 	 * @return mixed
+	 * @throws JsonException
 	 */
 	public static function decode(string $json, int $flags = 0)
 	{

--- a/src/Utils/ObjectHelpers.php
+++ b/src/Utils/ObjectHelpers.php
@@ -20,9 +20,7 @@ final class ObjectHelpers
 {
 	use Nette\StaticClass;
 
-	/**
-	 * @throws MemberAccessException
-	 */
+	/** @throws MemberAccessException */
 	public static function strictGet(string $class, string $name): void
 	{
 		$rc = new \ReflectionClass($class);
@@ -34,9 +32,7 @@ final class ObjectHelpers
 	}
 
 
-	/**
-	 * @throws MemberAccessException
-	 */
+	/** @throws MemberAccessException */
 	public static function strictSet(string $class, string $name): void
 	{
 		$rc = new \ReflectionClass($class);
@@ -48,9 +44,7 @@ final class ObjectHelpers
 	}
 
 
-	/**
-	 * @throws MemberAccessException
-	 */
+	/** @throws MemberAccessException */
 	public static function strictCall(string $class, string $method, array $additionalMethods = []): void
 	{
 		$hint = self::getSuggestion(array_merge(
@@ -66,9 +60,7 @@ final class ObjectHelpers
 	}
 
 
-	/**
-	 * @throws MemberAccessException
-	 */
+	/** @throws MemberAccessException */
 	public static function strictStaticCall(string $class, string $method): void
 	{
 		$hint = self::getSuggestion(
@@ -103,10 +95,10 @@ final class ObjectHelpers
 			$uname = ucfirst($name);
 			$write = $type !== '-read'
 				&& $rc->hasMethod($nm = 'set' . $uname)
-				&& ($rm = $rc->getMethod($nm)) && $rm->getName() === $nm && !$rm->isPrivate() && !$rm->isStatic();
+				&& ($rm = $rc->getMethod($nm))->getName() === $nm && !$rm->isPrivate() && !$rm->isStatic();
 			$read = $type !== '-write'
 				&& ($rc->hasMethod($nm = 'get' . $uname) || $rc->hasMethod($nm = 'is' . $uname))
-				&& ($rm = $rc->getMethod($nm)) && $rm->getName() === $nm && !$rm->isPrivate() && !$rm->isStatic();
+				&& ($rm = $rc->getMethod($nm))->getName() === $nm && !$rm->isPrivate() && !$rm->isStatic();
 
 			if ($read || $write) {
 				$props[$name] = $read << 0 | ($nm[0] === 'g') << 1 | $rm->returnsReference() << 2 | $write << 3;

--- a/src/Utils/ObjectMixin.php
+++ b/src/Utils/ObjectMixin.php
@@ -20,9 +20,7 @@ final class ObjectMixin
 {
 	use Nette\StaticClass;
 
-	/**
-	 * @deprecated  use ObjectHelpers::getSuggestion()
-	 */
+	/** @deprecated  use ObjectHelpers::getSuggestion() */
 	public static function getSuggestion(array $possibilities, string $value): ?string
 	{
 		trigger_error(__METHOD__ . '() has been renamed to Nette\Utils\ObjectHelpers::getSuggestion()', E_USER_DEPRECATED);
@@ -30,13 +28,13 @@ final class ObjectMixin
 	}
 
 
-	public static function setExtensionMethod($class, $name, $callback)
+	public static function setExtensionMethod(): void
 	{
 		trigger_error('Class Nette\Utils\ObjectMixin is deprecated', E_USER_DEPRECATED);
 	}
 
 
-	public static function getExtensionMethod($class, $name)
+	public static function getExtensionMethod(): void
 	{
 		trigger_error('Class Nette\Utils\ObjectMixin is deprecated', E_USER_DEPRECATED);
 	}

--- a/src/Utils/Reflection.php
+++ b/src/Utils/Reflection.php
@@ -58,6 +58,9 @@ final class Reflection
 	}
 
 
+	/**
+	 * @param  \ReflectionMethod|\ReflectionParameter|\ReflectionProperty  $reflection
+	 */
 	private static function normalizeType(string $type, $reflection): string
 	{
 		$lower = strtolower($type);
@@ -289,7 +292,7 @@ final class Reflection
 	}
 
 
-	private static function fetch(&$tokens, $take)
+	private static function fetch(array &$tokens, $take): ?string
 	{
 		$res = null;
 		while ($token = current($tokens)) {

--- a/src/Utils/Reflection.php
+++ b/src/Utils/Reflection.php
@@ -189,9 +189,7 @@ final class Reflection
 	}
 
 
-	/**
-	 * @return array of [alias => class]
-	 */
+	/** @return array of [alias => class] */
 	public static function getUseStatements(\ReflectionClass $class): array
 	{
 		if ($class->isAnonymous()) {

--- a/src/Utils/Reflection.php
+++ b/src/Utils/Reflection.php
@@ -84,9 +84,7 @@ final class Reflection
 			$const = $orig = $param->getDefaultValueConstantName();
 			$pair = explode('::', $const);
 			if (isset($pair[1])) {
-				if (strtolower($pair[0]) === 'self') {
-					$pair[0] = $param->getDeclaringClass()->getName();
-				}
+				$pair[0] = self::normalizeType($pair[0], $param);
 				try {
 					$rcc = new \ReflectionClassConstant($pair[0], $pair[1]);
 				} catch (\ReflectionException $e) {

--- a/src/Utils/Reflection.php
+++ b/src/Utils/Reflection.php
@@ -33,24 +33,27 @@ final class Reflection
 
 	public static function getReturnType(\ReflectionFunctionAbstract $func): ?string
 	{
-		return $func->hasReturnType()
-			? self::normalizeType($func->getReturnType()->getName(), $func)
+		$type = $func->getReturnType();
+		return $type instanceof \ReflectionNamedType && $func instanceof \ReflectionMethod
+			? self::normalizeType($type->getName(), $func)
 			: null;
 	}
 
 
 	public static function getParameterType(\ReflectionParameter $param): ?string
 	{
-		return $param->hasType()
-			? self::normalizeType($param->getType()->getName(), $param)
+		$type = $param->getType();
+		return $type instanceof \ReflectionNamedType
+			? self::normalizeType($type->getName(), $param)
 			: null;
 	}
 
 
 	public static function getPropertyType(\ReflectionProperty $prop): ?string
 	{
-		return PHP_VERSION_ID >= 70400 && $prop->hasType()
-			? self::normalizeType($prop->getType()->getName(), $prop)
+		$type = PHP_VERSION_ID >= 70400 ? $prop->getType() : null;
+		return $type instanceof \ReflectionNamedType
+			? self::normalizeType($type->getName(), $prop)
 			: null;
 	}
 

--- a/src/Utils/SmartObject.php
+++ b/src/Utils/SmartObject.php
@@ -21,8 +21,8 @@ use Nette\Utils\ObjectHelpers;
  */
 trait SmartObject
 {
-
 	/**
+	 * @return void
 	 * @throws MemberAccessException
 	 */
 	public function __call(string $name, array $args)
@@ -45,6 +45,7 @@ trait SmartObject
 
 
 	/**
+	 * @return void
 	 * @throws MemberAccessException
 	 */
 	public static function __callStatic(string $name, array $args)
@@ -79,6 +80,7 @@ trait SmartObject
 
 
 	/**
+	 * @param  mixed  $value
 	 * @return void
 	 * @throws MemberAccessException if the property is not defined or is read-only
 	 */

--- a/src/Utils/StaticClass.php
+++ b/src/Utils/StaticClass.php
@@ -27,6 +27,7 @@ trait StaticClass
 
 	/**
 	 * Call to undefined static method.
+	 * @return void
 	 * @throws MemberAccessException
 	 */
 	public static function __callStatic(string $name, array $args)

--- a/src/Utils/StaticClass.php
+++ b/src/Utils/StaticClass.php
@@ -15,10 +15,7 @@ namespace Nette;
  */
 trait StaticClass
 {
-
-	/**
-	 * @throws \Error
-	 */
+	/** @throws \Error */
 	final public function __construct()
 	{
 		throw new \Error('Class ' . get_class($this) . ' is static and cannot be instantiated.');

--- a/src/Utils/Strings.php
+++ b/src/Utils/Strings.php
@@ -101,7 +101,7 @@ class Strings
 	/**
 	 * Removes special controls characters and normalizes line endings, spaces and normal form to NFC in UTF-8 string.
 	 */
-	public static function normalize(string $s): string
+	public static function normalize(string $s, bool $fixMalformedData = false): string
 	{
 		// convert to compressed normal form (NFC)
 		if (class_exists('Normalizer', false) && ($n = \Normalizer::normalize($s, \Normalizer::FORM_C)) !== false) {
@@ -109,6 +109,10 @@ class Strings
 		}
 
 		$s = self::normalizeNewLines($s);
+
+		if ($fixMalformedData === true && function_exists('mb_convert_encoding')) {
+			$s = mb_convert_encoding($s, 'UTF-8', 'UTF-8');
+		}
 
 		// remove control characters; leave \t + \n
 		$s = self::pcre('preg_replace', ['#[\x00-\x08\x0B-\x1F\x7F-\x9F]+#u', '', $s]);

--- a/src/Utils/Validators.php
+++ b/src/Utils/Validators.php
@@ -19,6 +19,7 @@ class Validators
 {
 	use Nette\StaticClass;
 
+	/** @var array<string,?callable> */
 	protected static $validators = [
 		// PHP types
 		'array' => 'is_array',
@@ -68,6 +69,7 @@ class Validators
 		'type' => [__CLASS__, 'isType'],
 	];
 
+	/** @var array<string,callable> */
 	protected static $counters = [
 		'string' => 'strlen',
 		'unicode' => [Strings::class, 'length'],
@@ -85,6 +87,7 @@ class Validators
 
 	/**
 	 * Throws exception if a variable is of unexpected type (separated by pipe).
+	 * @param  mixed  $value
 	 */
 	public static function assert($value, string $expected, string $label = 'variable'): void
 	{
@@ -104,6 +107,8 @@ class Validators
 
 	/**
 	 * Throws exception if an array field is missing or of unexpected type (separated by pipe).
+	 * @param  mixed[]  $arr
+	 * @param  int|string  $field
 	 */
 	public static function assertField(array $arr, $field, string $expected = null, string $label = "item '%' in array"): void
 	{
@@ -118,6 +123,7 @@ class Validators
 
 	/**
 	 * Finds whether a variable is of expected type (separated by pipe).
+	 * @param  mixed  $value
 	 */
 	public static function is($value, string $expected): bool
 	{
@@ -173,6 +179,7 @@ class Validators
 
 	/**
 	 * Finds whether all values are of expected type (separated by pipe).
+	 * @param  mixed[]  $values
 	 */
 	public static function everyIs(iterable $values, string $expected): bool
 	{
@@ -187,6 +194,7 @@ class Validators
 
 	/**
 	 * Finds whether a value is an integer or a float.
+	 * @param  mixed  $value
 	 */
 	public static function isNumber($value): bool
 	{
@@ -196,6 +204,7 @@ class Validators
 
 	/**
 	 * Finds whether a value is an integer.
+	 * @param  mixed  $value
 	 */
 	public static function isNumericInt($value): bool
 	{
@@ -205,6 +214,7 @@ class Validators
 
 	/**
 	 * Finds whether a string is a floating point number in decimal base.
+	 * @param  mixed  $value
 	 */
 	public static function isNumeric($value): bool
 	{
@@ -214,6 +224,7 @@ class Validators
 
 	/**
 	 * Finds whether a value is a syntactically correct callback.
+	 * @param  mixed  $value
 	 */
 	public static function isCallable($value): bool
 	{
@@ -223,6 +234,7 @@ class Validators
 
 	/**
 	 * Finds whether a value is an UTF-8 encoded string.
+	 * @param  mixed  $value
 	 */
 	public static function isUnicode($value): bool
 	{
@@ -232,6 +244,7 @@ class Validators
 
 	/**
 	 * Finds whether a value is "falsy".
+	 * @param  mixed  $value
 	 */
 	public static function isNone($value): bool
 	{
@@ -248,6 +261,7 @@ class Validators
 
 	/**
 	 * Finds whether a variable is a zero-based integer indexed array.
+	 * @param  mixed  $value
 	 */
 	public static function isList($value): bool
 	{
@@ -257,6 +271,7 @@ class Validators
 
 	/**
 	 * Is a value in specified min and max value pair?
+	 * @param  mixed  $value
 	 */
 	public static function isInRange($value, array $range): bool
 	{

--- a/tests/Utils/Reflection.getParameterDefaultValue.phpt
+++ b/tests/Utils/Reflection.getParameterDefaultValue.phpt
@@ -31,6 +31,8 @@ Assert::same('abc', Reflection::getParameterDefaultValue(new ReflectionParameter
 
 Assert::same('abc', Reflection::getParameterDefaultValue(new ReflectionParameter(['NS\Foo', 'method'], 'h')));
 
+Assert::same('xyz', Reflection::getParameterDefaultValue(new ReflectionParameter(['NS\Foo', 'method'], 'p')));
+
 Assert::exception(function () {
 	Reflection::getParameterDefaultValue(new ReflectionParameter(['NS\Foo', 'method'], 'i'));
 }, ReflectionException::class, 'Unable to resolve constant self::UNDEFINED used as default value of $i in NS\Foo::method().');

--- a/tests/Utils/fixtures.reflection/defaultValue.php
+++ b/tests/Utils/fixtures.reflection/defaultValue.php
@@ -13,7 +13,12 @@ interface Bar
 	const DEFINED = 'xyz';
 }
 
-class Foo
+class ParentFoo
+{
+	public const PUBLIC_DEFINED = 'xyz';
+}
+
+class Foo extends ParentFoo
 {
 	public const PUBLIC_DEFINED = 'abc';
 	protected const PROTECTED_DEFINED = 'abc';
@@ -35,7 +40,8 @@ class Foo
 		$l = Undefined::ANY,
 		$m = DEFINED,
 		$n = UNDEFINED,
-		$o = NS_DEFINED
+		$o = NS_DEFINED,
+		$p = parent::PUBLIC_DEFINED
 	) {
 	}
 }

--- a/tests/phpstan.neon
+++ b/tests/phpstan.neon
@@ -7,3 +7,6 @@ parameters:
 
 		# PHPStan does not support RecursiveIteratorIterator proxying unknown method calls to inner iterator
 		- '#RecursiveIteratorIterator::getSubPathName\(\)#'
+
+		# static cannot be changed to maintain backward compatibility
+		- '#Unsafe usage of new static\(\)#'


### PR DESCRIPTION
- new feature
- BC break? yes

Add back compatibility support and parameter for fix broken string for example from database:

Current behavior:

![Snímek obrazovky 2020-02-05 v 18 48 44](https://user-images.githubusercontent.com/4738758/73868073-24c5a800-4848-11ea-885f-e71ec4729267.png)

Thanks.