### PR TITLE
Image: Return sizes must be integer only.

### DIFF
--- a/src/Utils/Image.php
+++ b/src/Utils/Image.php
@@ -428,7 +428,7 @@ class Image
 		}
 		$newWidth = min($newWidth, $srcWidth - $left);
 		$newHeight = min($newHeight, $srcHeight - $top);
-		return [$left, $top, $newWidth, $newHeight];
+		return [(int) $left, (int) $top, (int) $newWidth, (int) $newHeight];
 	}
 
 


### PR DESCRIPTION
- bug fix
- BC break? yes

I think return sizes from `calculateCutout` must be `int` only.

In case of `float` Image throw `TypeError`:

![Snímek obrazovky 2020-02-17 v 14 51 34](https://user-images.githubusercontent.com/4738758/74659635-ff646280-5194-11ea-869e-b94ba8ebec61.png)

Thansk.