### PR TITLE
Fixed type issue in crop function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 		"phpstan/phpstan": "^0.12"
 	},
 	"suggest": {
-		"ext-iconv": "to use Strings::webalize() and toAscii()",
+		"ext-iconv": "to use Strings::webalize(), toAscii(), chr() and reverse()",
 		"ext-json": "to use Nette\\Utils\\Json",
 		"ext-intl": "to use Strings::webalize(), toAscii(), normalize() and compare()",
 		"ext-mbstring": "to use Strings::lower() etc...",

--- a/src/Utils/Image.php
+++ b/src/Utils/Image.php
@@ -428,7 +428,7 @@ class Image
 		}
 		$newWidth = min($newWidth, $srcWidth - $left);
 		$newHeight = min($newHeight, $srcHeight - $top);
-		return [$left, $top, $newWidth, $newHeight];
+		return [(int) $left, (int) $top, (int) $newWidth, (int) $newHeight];
 	}
 
 

--- a/src/Utils/Strings.php
+++ b/src/Utils/Strings.php
@@ -141,9 +141,7 @@ class Strings
 	 */
 	public static function toAscii(string $s): string
 	{
-		if (!extension_loaded('iconv')) {
-			throw new Nette\NotSupportedException(__METHOD__ . '() requires ICONV extension that is not loaded.');
-		}
+		$iconv = defined('ICONV_IMPL') ? ICONV_IMPL : null;
 		static $transliterator = null;
 		if ($transliterator === null && class_exists('Transliterator', false)) {
 			$transliterator = \Transliterator::create('Any-Latin; Latin-ASCII');
@@ -154,24 +152,26 @@ class Strings
 
 		// transliteration (by Transliterator and iconv) is not optimal, replace some characters directly
 		$s = strtr($s, ["\u{201E}" => '"', "\u{201C}" => '"', "\u{201D}" => '"', "\u{201A}" => "'", "\u{2018}" => "'", "\u{2019}" => "'", "\u{B0}" => '^', "\u{42F}" => 'Ya', "\u{44F}" => 'ya', "\u{42E}" => 'Yu', "\u{44E}" => 'yu']); // „ “ ” ‚ ‘ ’ ° Я я Ю ю
-		if (ICONV_IMPL === 'glibc') {
+		if ($iconv !== 'libiconv') {
 			$s = strtr($s, ["\u{AE}" => '(R)', "\u{A9}" => '(c)', "\u{2026}" => '...', "\u{AB}" => '<<', "\u{BB}" => '>>', "\u{A3}" => 'lb', "\u{A5}" => 'yen', "\u{B2}" => '^2', "\u{B3}" => '^3', "\u{B5}" => 'u', "\u{B9}" => '^1', "\u{BA}" => 'o', "\u{BF}" => '?', "\u{2CA}" => "'", "\u{2CD}" => '_', "\u{2DD}" => '"', "\u{1FEF}" => '', "\u{20AC}" => 'EUR', "\u{2122}" => 'TM', "\u{212E}" => 'e', "\u{2190}" => '<-', "\u{2191}" => '^', "\u{2192}" => '->', "\u{2193}" => 'V', "\u{2194}" => '<->']); // ® © … « » £ ¥ ² ³ µ ¹ º ¿ ˊ ˍ ˝ ` € ™ ℮ ← ↑ → ↓ ↔
 		}
 
 		if ($transliterator) {
 			$s = $transliterator->transliterate($s);
-			if (ICONV_IMPL === 'glibc') { // temporarily hide ? to distinguish them from the garbage that iconv creates
-				$s = strtr($s, '?', "\x01");
-			}
 			// use iconv because The transliterator leaves some characters out of ASCII, eg → ʾ
-			$s = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $s);
-			if (ICONV_IMPL === 'glibc') { // remove garbage and restore ? characters
-				$s = str_replace(['?', "\x01"], ['', '?'], $s);
+			if ($iconv === 'glibc') {
+				$s = strtr($s, '?', "\x01"); // temporarily hide ? to distinguish them from the garbage that iconv creates
+				$s = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $s);
+				$s = str_replace(['?', "\x01"], ['', '?'], $s); // remove garbage and restore ? characters
+			} elseif ($iconv === 'libiconv') {
+				$s = iconv('UTF-8', 'ASCII//TRANSLIT//IGNORE', $s);
+			} else { // null or 'unknown' (#216)
+				$s = self::pcre('preg_replace', ['#[^\x00-\x7F]++#', '', $s]); // remove non-ascii chars
 			}
-		} else {
+		} elseif ($iconv === 'glibc' || $iconv === 'libiconv') {
 			// temporarily hide these characters to distinguish them from the garbage that iconv creates
 			$s = strtr($s, '`\'"^~?', "\x01\x02\x03\x04\x05\x06");
-			if (ICONV_IMPL === 'glibc') {
+			if ($iconv === 'glibc') {
 				// glibc implementation is very limited. transliterate into Windows-1250 and then into ASCII, so most Eastern European characters are preserved
 				$s = iconv('UTF-8', 'WINDOWS-1250//TRANSLIT//IGNORE', $s);
 				$s = strtr($s,
@@ -185,6 +185,8 @@ class Strings
 			$s = str_replace(['`', "'", '"', '^', '~', '?'], '', $s);
 			// restore temporarily hidden characters
 			$s = strtr($s, "\x01\x02\x03\x04\x05\x06", '`\'"^~?');
+		} else {
+			$s = self::pcre('preg_replace', ['#[^\x00-\x7F]++#', '', $s]); // remove non-ascii chars
 		}
 
 		return $s;

--- a/src/Utils/Strings.php
+++ b/src/Utils/Strings.php
@@ -50,6 +50,8 @@ class Strings
 	{
 		if ($code < 0 || ($code >= 0xD800 && $code <= 0xDFFF) || $code > 0x10FFFF) {
 			throw new Nette\InvalidArgumentException('Code point must be in range 0x0 to 0xD7FF or 0xE000 to 0x10FFFF.');
+		} elseif (!extension_loaded('iconv')) {
+			throw new Nette\NotSupportedException(__METHOD__ . '() requires ICONV extension that is not loaded.');
 		}
 		return iconv('UTF-32BE', 'UTF-8//IGNORE', pack('N', $code));
 	}
@@ -89,6 +91,8 @@ class Strings
 	{
 		if (function_exists('mb_substr')) {
 			return mb_substr($s, $start, $length, 'UTF-8'); // MB is much faster
+		} elseif (!extension_loaded('iconv')) {
+			throw new Nette\NotSupportedException(__METHOD__ . '() requires extension ICONV or MBSTRING, neither is loaded.');
 		} elseif ($length === null) {
 			$length = self::length($s);
 		} elseif ($start < 0 && $length < 0) {
@@ -137,6 +141,9 @@ class Strings
 	 */
 	public static function toAscii(string $s): string
 	{
+		if (!extension_loaded('iconv')) {
+			throw new Nette\NotSupportedException(__METHOD__ . '() requires ICONV extension that is not loaded.');
+		}
 		static $transliterator = null;
 		if ($transliterator === null && class_exists('Transliterator', false)) {
 			$transliterator = \Transliterator::create('Any-Latin; Latin-ASCII');
@@ -366,6 +373,9 @@ class Strings
 	 */
 	public static function reverse(string $s): string
 	{
+		if (!extension_loaded('iconv')) {
+			throw new Nette\NotSupportedException(__METHOD__ . '() requires ICONV extension that is not loaded.');
+		}
 		return iconv('UTF-32LE', 'UTF-8', strrev(iconv('UTF-8', 'UTF-32BE', $s)));
 	}
 


### PR DESCRIPTION
* bug fix
* BC break? no

When type of width and height is string without "%" char, line 392 and 393 throws "must be of the type integer, string given". (Happened with webchemistry/images img macro with exact resize).
