### PR TITLE
FileSystem::write(): Exception should contain current mode for better debug

### DIFF
--- a/src/Utils/FileSystem.php
+++ b/src/Utils/FileSystem.php
@@ -138,7 +138,7 @@ final class FileSystem
 			throw new Nette\IOException("Unable to write file '$file'. " . Helpers::getLastError());
 		}
 		if ($mode !== null && !@chmod($file, $mode)) { // @ is escalated to exception
-			throw new Nette\IOException("Unable to chmod file '$file'. " . Helpers::getLastError());
+			throw new Nette\IOException("Unable to chmod file '$file' with mode '$mode'. " . Helpers::getLastError());
 		}
 	}
 


### PR DESCRIPTION
- new feature
- BC break? no

For production debug is better when current mode is displayed in exception message.
