### PR TITLE
Fix ICONV_IMPL constant

### DIFF
--- a/src/Utils/Strings.php
+++ b/src/Utils/Strings.php
@@ -141,7 +141,7 @@ class Strings
 	 */
 	public static function toAscii(string $s): string
 	{
-		$iconv = defined('ICONV_IMPL') ? trim(ICONV_IMPL, '"'."'") : null;
+		$iconv = defined('ICONV_IMPL') ? trim(ICONV_IMPL, '"' . "'") : null;
 		static $transliterator = null;
 		if ($transliterator === null && class_exists('Transliterator', false)) {
 			$transliterator = \Transliterator::create('Any-Latin; Latin-ASCII');

--- a/src/Utils/Strings.php
+++ b/src/Utils/Strings.php
@@ -141,7 +141,7 @@ class Strings
 	 */
 	public static function toAscii(string $s): string
 	{
-		$iconv = defined('ICONV_IMPL') ? ICONV_IMPL : null;
+		$iconv = defined('ICONV_IMPL') ? trim(ICONV_IMPL, '"'."'") : null;
 		static $transliterator = null;
 		if ($transliterator === null && class_exists('Transliterator', false)) {
 			$transliterator = \Transliterator::create('Any-Latin; Latin-ASCII');


### PR DESCRIPTION
- bug fix
- BC break? no

Constant ICONV_IMPL can contain quotes on some systems.
I could not find any official description why that is, same problem was reported here for example https://github.com/techdivision/import/pull/173
