### PR TITLE
SmartObject: __set() and __unset() compatibility with Latte Strict trait

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, windows-latest, macOS-latest]
-                php: ['7.1', '7.2', '7.3', '7.4', '8.0']
+                php: ['7.2', '7.3', '7.4', '8.0']
 
             fail-fast: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-    - 7.1
     - 7.2
     - 7.3
     - 7.4
@@ -58,7 +57,7 @@ jobs:
         -   stage: Code Coverage
 
 
-sudo: false
+dist: xenial
 
 cache:
     directories:

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "3.1-dev"
+			"dev-master": "3.2-dev"
 		}
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		}
 	],
 	"require": {
-		"php": ">=7.1"
+		"php": ">=7.2 <8.1"
 	},
 	"require-dev": {
 		"nette/tester": "~2.0",

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,7 @@ The recommended way to install is via Composer:
 composer require nette/utils
 ```
 
+- Nette Utils 3.2 is compatible with PHP 7.2 to 8.0
 - Nette Utils 3.1 is compatible with PHP 7.1 to 8.0
 - Nette Utils 3.0 is compatible with PHP 7.1 to 8.0
 - Nette Utils 2.5 is compatible with PHP 5.6 to 8.0

--- a/src/Utils/Floats.php
+++ b/src/Utils/Floats.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (https://nette.org)
+ * Copyright (c) 2004 David Grudl (https://davidgrudl.com)
+ */
+
+declare(strict_types=1);
+
+namespace Nette\Utils;
+
+use Nette;
+
+
+/**
+ * Floats compare tools library.
+ */
+class Floats
+{
+	use Nette\StaticClass;
+
+	private const EPSILON = 1e-10;
+
+
+	public static function isZero(float $value): bool
+	{
+		return abs($value) < self::EPSILON;
+	}
+
+
+	public static function isInteger(float $value): bool
+	{
+		return abs(round($value) - $value) < self::EPSILON;
+	}
+
+
+	/**
+	 * Compare two floats. If $a < $b it returns -1, if they are equal it returns 0 and if $a > $b it returns 1
+	 * @throws \LogicException if one of parameters is NAN
+	 */
+	public static function compare(float $a, float $b): int
+	{
+		if (is_nan($a) || is_nan($b)) {
+			throw new \LogicException('Trying to compare NAN');
+
+		} elseif (!is_finite($a) && !is_finite($b) && $a === $b) {
+			return 0;
+		}
+
+		$diff = abs($a - $b);
+		if (($diff < self::EPSILON || ($diff / max(abs($a), abs($b)) < self::EPSILON))) {
+			return 0;
+		}
+
+		return $a < $b ? -1 : 1;
+	}
+
+
+	/**
+	 * Returns true if $a = $b
+	 * @throws \LogicException if one of parameters is NAN
+	 */
+	public static function areEqual(float $a, float $b): bool
+	{
+		return self::compare($a, $b) === 0;
+	}
+
+
+	/**
+	 * Returns true if $a < $b
+	 * @throws \LogicException if one of parameters is NAN
+	 */
+	public static function isLessThan(float $a, float $b): bool
+	{
+		return self::compare($a, $b) < 0;
+	}
+
+
+	/**
+	 * Returns true if $a <= $b
+	 * @throws \LogicException if one of parameters is NAN
+	 */
+	public static function isLessThanOrEqualTo(float $a, float $b): bool
+	{
+		return self::compare($a, $b) <= 0;
+	}
+
+
+	/**
+	 * Returns true if $a > $b
+	 * @throws \LogicException if one of parameters is NAN
+	 */
+	public static function isGreaterThan(float $a, float $b): bool
+	{
+		return self::compare($a, $b) > 0;
+	}
+
+
+	/**
+	 * Returns true if $a >= $b
+	 * @throws \LogicException if one of parameters is NAN
+	 */
+	public static function isGreaterThanOrEqualTo(float $a, float $b): bool
+	{
+		return self::compare($a, $b) >= 0;
+	}
+}

--- a/src/Utils/Html.php
+++ b/src/Utils/Html.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Nette\Utils;
 
 use Nette;
+use Nette\HtmlStringable;
 use function is_array, is_float, is_object, is_string;
 
 
@@ -230,7 +231,7 @@ use function is_array, is_float, is_object, is_string;
  * @method self width(?int $val)
  * @method self wrap(?string $val)
  */
-class Html implements \ArrayAccess, \Countable, \IteratorAggregate, IHtmlString
+class Html implements \ArrayAccess, \Countable, \IteratorAggregate, HtmlStringable
 {
 	use Nette\SmartObject;
 
@@ -548,7 +549,7 @@ class Html implements \ArrayAccess, \Countable, \IteratorAggregate, IHtmlString
 
 	/**
 	 * Sets element's HTML content.
-	 * @param  IHtmlString|string  $html
+	 * @param  HtmlStringable|string  $html
 	 * @return static
 	 */
 	final public function setHtml($html)
@@ -569,12 +570,12 @@ class Html implements \ArrayAccess, \Countable, \IteratorAggregate, IHtmlString
 
 	/**
 	 * Sets element's textual content.
-	 * @param  IHtmlString|string|int|float  $text
+	 * @param  HtmlStringable|string|int|float  $text
 	 * @return static
 	 */
 	final public function setText($text)
 	{
-		if (!$text instanceof IHtmlString) {
+		if (!$text instanceof HtmlStringable) {
 			$text = htmlspecialchars((string) $text, ENT_NOQUOTES, 'UTF-8');
 		}
 		$this->children = [(string) $text];
@@ -593,7 +594,7 @@ class Html implements \ArrayAccess, \Countable, \IteratorAggregate, IHtmlString
 
 	/**
 	 * Adds new element's child.
-	 * @param  IHtmlString|string  $child  Html node or raw HTML string
+	 * @param  HtmlStringable|string  $child  Html node or raw HTML string
 	 * @return static
 	 */
 	final public function addHtml($child)
@@ -604,12 +605,12 @@ class Html implements \ArrayAccess, \Countable, \IteratorAggregate, IHtmlString
 
 	/**
 	 * Appends plain-text string to element content.
-	 * @param  IHtmlString|string|int|float  $text
+	 * @param  HtmlStringable|string|int|float  $text
 	 * @return static
 	 */
 	public function addText($text)
 	{
-		if (!$text instanceof IHtmlString) {
+		if (!$text instanceof HtmlStringable) {
 			$text = htmlspecialchars((string) $text, ENT_NOQUOTES, 'UTF-8');
 		}
 		return $this->insert(null, $text);
@@ -630,7 +631,7 @@ class Html implements \ArrayAccess, \Countable, \IteratorAggregate, IHtmlString
 
 	/**
 	 * Inserts child node.
-	 * @param  IHtmlString|string $child Html node or raw HTML string
+	 * @param  HtmlStringable|string $child Html node or raw HTML string
 	 * @return static
 	 */
 	public function insert(?int $index, $child, bool $replace = false)

--- a/src/Utils/HtmlStringable.php
+++ b/src/Utils/HtmlStringable.php
@@ -7,13 +7,16 @@
 
 declare(strict_types=1);
 
-namespace Nette\Utils;
+namespace Nette;
 
 
-interface IHtmlString
+interface HtmlStringable
 {
 	/**
 	 * Returns string in HTML format
 	 */
 	function __toString(): string;
 }
+
+
+interface_exists(Utils\IHtmlString::class);

--- a/src/Utils/SmartObject.php
+++ b/src/Utils/SmartObject.php
@@ -83,7 +83,7 @@ trait SmartObject
 	 * @return void
 	 * @throws MemberAccessException if the property is not defined or is read-only
 	 */
-	public function __set(string $name, $value)
+	public function __set(string $name, $value): void
 	{
 		$class = static::class;
 
@@ -106,7 +106,7 @@ trait SmartObject
 	 * @return void
 	 * @throws MemberAccessException
 	 */
-	public function __unset(string $name)
+	public function __unset(string $name): void
 	{
 		$class = static::class;
 		if (!ObjectHelpers::hasProperty($class, $name)) {

--- a/src/Utils/Strings.php
+++ b/src/Utils/Strings.php
@@ -145,8 +145,13 @@ class Strings
 	{
 		$iconv = defined('ICONV_IMPL') ? trim(ICONV_IMPL, '"\'') : null;
 		static $transliterator = null;
-		if ($transliterator === null && class_exists('Transliterator', false)) {
-			$transliterator = \Transliterator::create('Any-Latin; Latin-ASCII');
+		if ($transliterator === null) {
+			if (class_exists('Transliterator', false)) {
+				$transliterator = \Transliterator::create('Any-Latin; Latin-ASCII');
+			} else {
+				trigger_error(__METHOD__ . "(): it is recommended to enable PHP extensions 'intl'.", E_USER_NOTICE);
+				$transliterator = false;
+			}
 		}
 
 		// remove control characters and check UTF-8 validity

--- a/src/Utils/Translator.php
+++ b/src/Utils/Translator.php
@@ -13,7 +13,7 @@ namespace Nette\Localization;
 /**
  * Translator adapter.
  */
-interface ITranslator
+interface Translator
 {
 	/**
 	 * Translates the given string.
@@ -22,3 +22,6 @@ interface ITranslator
 	 */
 	function translate($message, ...$parameters): string;
 }
+
+
+interface_exists(Nette\Localization\ITranslator::class);

--- a/src/compatibility.php
+++ b/src/compatibility.php
@@ -17,3 +17,14 @@ namespace Nette\Utils {
 		class_alias(\Nette\HtmlStringable::class, IHtmlString::class);
 	}
 }
+
+namespace Nette\Localization {
+	if (false) {
+		/** @deprecated use Nette\Localization\Translator */
+		interface ITranslator
+		{
+		}
+	} elseif (!interface_exists(ITranslator::class)) {
+		class_alias(Translator::class, ITranslator::class);
+	}
+}

--- a/src/compatibility.php
+++ b/src/compatibility.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * This file is part of the Nette Framework (https://nette.org)
+ * Copyright (c) 2004 David Grudl (https://davidgrudl.com)
+ */
+
+declare(strict_types=1);
+
+namespace Nette\Utils {
+	if (false) {
+		/** @deprecated use Nette\HtmlStringable */
+		interface IHtmlString
+		{
+		}
+	} elseif (!interface_exists(IHtmlString::class)) {
+		class_alias(\Nette\HtmlStringable::class, IHtmlString::class);
+	}
+}

--- a/tests/Utils/Floats.areEqual().phpt
+++ b/tests/Utils/Floats.areEqual().phpt
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Test: Nette\Utils\Floats::areEqual()
+ */
+
+declare(strict_types=1);
+
+use Nette\Utils\Floats;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+Assert::true(Floats::areEqual(9, 9));
+Assert::true(Floats::areEqual(9, 9.0));
+Assert::true(Floats::areEqual(3.0, 3));
+Assert::true(Floats::areEqual(0.0, 0));
+Assert::true(Floats::areEqual(0.0, 0.0));
+Assert::true(Floats::areEqual(0.1 + 0.2, 0.3));
+Assert::true(Floats::areEqual(0.1 - 0.5, -0.4));
+Assert::false(Floats::areEqual(0.0, 5));
+Assert::false(Floats::areEqual(-5, 5));
+Assert::false(Floats::areEqual(0.001, 0.01));
+
+$float1 = 1 / 3;
+$float2 = 1 - 2 / 3;
+Assert::true(Floats::areEqual($float1, $float2));
+Assert::true(Floats::areEqual($float1 * 1e9, $float2 * 1e9));
+Assert::true(Floats::areEqual($float1 - $float2, 0.0));
+Assert::true(Floats::areEqual($float1 - $float2 + 123, $float2 - $float1 + 123));
+Assert::true(Floats::areEqual($float1 - $float2, $float2 - $float1));
+
+Assert::true(Floats::areEqual(INF, INF));
+Assert::false(Floats::areEqual(INF, -INF));
+Assert::false(Floats::areEqual(-INF, INF));
+
+Assert::exception(function () {
+	Floats::areEqual(NAN, NAN);
+}, \LogicException::class);

--- a/tests/Utils/Floats.compare().phpt
+++ b/tests/Utils/Floats.compare().phpt
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Test: Nette\Utils\Floats::compare()
+ */
+
+declare(strict_types=1);
+
+use Nette\Utils\Floats;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+Assert::same(0, Floats::compare(0, 0));
+Assert::same(0, Floats::compare(0.0, 0));
+Assert::same(0, Floats::compare(0, 0x0));
+Assert::same(1, Floats::compare(0, -25.7));
+Assert::same(-1, Floats::compare(-2, 30.7));
+Assert::same(1, Floats::compare(0.0, -5));
+Assert::same(1, Floats::compare(20, 10));
+Assert::same(-1, Floats::compare(20, 30));
+Assert::same(1, Floats::compare(-20, -30));
+Assert::same(-1, Floats::compare(-50, -30));
+
+Assert::exception(function () {
+	Floats::compare(NAN, -30);
+}, \LogicException::class);
+
+Assert::exception(function () {
+	Floats::compare(6, NAN);
+}, \LogicException::class);
+
+Assert::exception(function () {
+	Floats::compare(NAN, NAN);
+}, \LogicException::class);

--- a/tests/Utils/Floats.isGreaterThan().phpt
+++ b/tests/Utils/Floats.isGreaterThan().phpt
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Test: Nette\Utils\Floats::isGreaterThan()
+ */
+
+declare(strict_types=1);
+
+use Nette\Utils\Floats;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+Assert::false(Floats::isGreaterThan(-9, 9));
+Assert::false(Floats::isGreaterThan(-9.7, 0.0));
+Assert::false(Floats::isGreaterThan(10, 150));
+Assert::false(Floats::isGreaterThan(0, 0.0));
+Assert::false(Floats::isGreaterThan(10, 10));
+Assert::false(Floats::isGreaterThan(-50, -50));
+Assert::true(Floats::isGreaterThan(170, 150));
+Assert::true(Floats::isGreaterThan(170.879, -20));
+Assert::true(Floats::isGreaterThan(11.879, 0.0));
+
+Assert::true(Floats::isGreaterThan(INF, -INF));
+Assert::false(Floats::isGreaterThan(INF, INF));
+Assert::false(Floats::isGreaterThan(-INF, INF));
+
+Assert::exception(function () {
+	Floats::isGreaterThan(NAN, NAN);
+}, \LogicException::class);

--- a/tests/Utils/Floats.isGreaterThanOrEqualTo().phpt
+++ b/tests/Utils/Floats.isGreaterThanOrEqualTo().phpt
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Test: Nette\Utils\Floats::isGreaterOrEqualThan()
+ */
+
+declare(strict_types=1);
+
+use Nette\Utils\Floats;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+Assert::false(Floats::isGreaterThanOrEqualTo(-9, 9));
+Assert::false(Floats::isGreaterThanOrEqualTo(-9.7, 0.0));
+Assert::false(Floats::isGreaterThanOrEqualTo(10, 150));
+Assert::true(Floats::isGreaterThanOrEqualTo(0, 0.0));
+Assert::true(Floats::isGreaterThanOrEqualTo(10, 10));
+Assert::true(Floats::isGreaterThanOrEqualTo(-50, -50));
+Assert::true(Floats::isGreaterThanOrEqualTo(170, 150));
+Assert::true(Floats::isGreaterThanOrEqualTo(170.879, -20));
+Assert::true(Floats::isGreaterThanOrEqualTo(11.879, 0.0));
+
+Assert::true(Floats::isGreaterThanOrEqualTo(INF, INF));
+Assert::true(Floats::isGreaterThanOrEqualTo(INF, -INF));
+Assert::false(Floats::isGreaterThanOrEqualTo(-INF, INF));
+
+Assert::exception(function () {
+	Floats::isGreaterThanOrEqualTo(NAN, NAN);
+}, \LogicException::class);

--- a/tests/Utils/Floats.isInteger().phpt
+++ b/tests/Utils/Floats.isInteger().phpt
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Test: Nette\Utils\Floats::isInteger()
+ */
+
+declare(strict_types=1);
+
+use Nette\Utils\Floats;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+Assert::true(Floats::isInteger(0));
+Assert::true(Floats::isInteger(0.0));
+Assert::true(Floats::isInteger(5.0));
+Assert::true(Floats::isInteger(-5.0));
+Assert::true(Floats::isInteger(-5));
+Assert::true(Floats::isInteger((1 - (0.1 + 0.2)) * 10));
+Assert::false(Floats::isInteger(-5.1));
+Assert::false(Floats::isInteger(0.000001));
+Assert::false(Floats::isInteger(NAN));
+Assert::false(Floats::isInteger(INF));

--- a/tests/Utils/Floats.isLessThan().phpt
+++ b/tests/Utils/Floats.isLessThan().phpt
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Test: Nette\Utils\Floats::isLowerThan()
+ */
+
+declare(strict_types=1);
+
+use Nette\Utils\Floats;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+Assert::true(Floats::isLessThan(-9, 9));
+Assert::true(Floats::isLessThan(-9.7, 0.0));
+Assert::true(Floats::isLessThan(10, 150));
+Assert::false(Floats::isLessThan(0, 0.0));
+Assert::false(Floats::isLessThan(10, 10));
+Assert::false(Floats::isLessThan(-50, -50));
+Assert::false(Floats::isLessThan(170, 150));
+Assert::false(Floats::isLessThan(170.879, -20));
+Assert::false(Floats::isLessThan(11.879, 0.0));
+
+Assert::true(Floats::isLessThan(-INF, INF));
+Assert::false(Floats::isLessThan(INF, INF));
+Assert::false(Floats::isLessThan(INF, -INF));
+
+Assert::exception(function () {
+	Floats::isLessThan(NAN, NAN);
+}, \LogicException::class);

--- a/tests/Utils/Floats.isLessThanOrEqualTo().phpt
+++ b/tests/Utils/Floats.isLessThanOrEqualTo().phpt
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Test: Nette\Utils\Floats::isLowerOrEqualThan()
+ */
+
+declare(strict_types=1);
+
+use Nette\Utils\Floats;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+Assert::true(Floats::isLessThanOrEqualTo(-9, 9));
+Assert::true(Floats::isLessThanOrEqualTo(-9.7, 0.0));
+Assert::true(Floats::isLessThanOrEqualTo(10, 150));
+Assert::true(Floats::isLessThanOrEqualTo(0, 0.0));
+Assert::true(Floats::isLessThanOrEqualTo(10, 10));
+Assert::true(Floats::isLessThanOrEqualTo(-50, -50));
+Assert::false(Floats::isLessThanOrEqualTo(170, 150));
+Assert::false(Floats::isLessThanOrEqualTo(170.879, -20));
+Assert::false(Floats::isLessThanOrEqualTo(11.879, 0.0));
+
+Assert::true(Floats::isLessThanOrEqualTo(-INF, INF));
+Assert::true(Floats::isLessThanOrEqualTo(INF, INF));
+Assert::false(Floats::isLessThanOrEqualTo(INF, -INF));
+
+Assert::exception(function () {
+	Floats::isLessThanOrEqualTo(NAN, NAN);
+}, \LogicException::class);

--- a/tests/Utils/Floats.isZero().phpt
+++ b/tests/Utils/Floats.isZero().phpt
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Test: Nette\Utils\Floats::isZero()
+ */
+
+declare(strict_types=1);
+
+use Nette\Utils\Floats;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+Assert::true(Floats::isZero(0));
+Assert::true(Floats::isZero(0.0));
+Assert::true(Floats::isZero(0x0));
+Assert::false(Floats::isZero(-12.5));
+Assert::false(Floats::isZero(0.2));
+Assert::false(Floats::isZero(20));
+Assert::false(Floats::isZero(-2));
+Assert::false(Floats::isZero(0x5));
+Assert::false(Floats::isZero(INF));
+Assert::false(Floats::isZero(NAN));

--- a/tests/Utils/Html.basic.phpt
+++ b/tests/Utils/Html.basic.phpt
@@ -113,7 +113,7 @@ test('attributes escaping', function () {
 });
 
 
-class BR implements Nette\Utils\IHtmlString
+class BR implements Nette\HtmlStringable
 {
 	public function __toString(): string
 	{


### PR DESCRIPTION
- bug fix
- BC break? yes

Latte trait `Strict` should be compatible with `SmartObject`, because some packages use `SmartObject` inside `MacroSet`.

![Snímek obrazovky 2020-11-23 v 20 03 51](https://user-images.githubusercontent.com/4738758/100004052-3cfeb780-2dc7-11eb-8823-f3cab1cb5eff.png)
