### PR TITLE
Arrays::updateDiff()

### DIFF
--- a/src/Utils/Arrays.php
+++ b/src/Utils/Arrays.php
@@ -343,4 +343,19 @@ class Arrays
 	{
 		return key([$value => null]);
 	}
+
+
+	/**
+	 * Returns items required to synchronize associative array $from to array $to.
+	 */
+	public static function updateDiff(array $from, array $to): array
+	{
+		$diff = [];
+		foreach ($to as $k => $v) {
+			if (!array_key_exists($k, $from) || $v !== $from[$k]) {
+				$diff[$k] = $v;
+			}
+		}
+		return $diff;
+	}
 }

--- a/src/Utils/Callback.php
+++ b/src/Utils/Callback.php
@@ -36,6 +36,19 @@ final class Callback
 
 
 	/**
+	 * Invokes all callables.
+	 * @param  callable[]  $callables
+	 */
+	public static function invokeAll(array $callables, ...$args): array
+	{
+		foreach ($callables as $k => $cb) {
+			$callables[$k] = $cb(...$args);
+		}
+		return $callables;
+	}
+
+
+	/**
 	 * Invokes callback.
 	 * @return mixed
 	 * @deprecated

--- a/tests/Utils/Arrays.updateDiff().phpt
+++ b/tests/Utils/Arrays.updateDiff().phpt
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Test: Nette\Utils\Arrays::updateDiff()
+ */
+
+declare(strict_types=1);
+
+use Nette\Utils\Arrays;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+test('Basics', function () {
+	Assert::same([], Arrays::updateDiff([], []));
+	Assert::same([], Arrays::updateDiff(['a' => ''], []));
+});
+
+
+test('New keys', function () {
+	$to = [
+		'a' => null,
+		'b' => false,
+		'c' => '',
+		'd' => 0,
+	];
+	Assert::same($to, Arrays::updateDiff([], $to));
+});
+
+
+test('To falsy values', function () {
+	$from = [
+		'a' => null,
+		'b' => false,
+		'c' => '',
+		'd' => 0,
+	];
+
+	$toNull = ['a' => null, 'b' => null, 'c' => null, 'd' => null];
+	Assert::same([
+		'b' => null,
+		'c' => null,
+		'd' => null,
+	], Arrays::updateDiff($from, $toNull));
+
+
+	$toFalse = ['a' => false, 'b' => false, 'c' => false, 'd' => false];
+	Assert::same([
+		'a' => false,
+		'c' => false,
+		'd' => false,
+	], Arrays::updateDiff($from, $toFalse));
+
+
+	$toEmpty = ['a' => '', 'b' => '', 'c' => '', 'd' => ''];
+	Assert::same([
+		'a' => '',
+		'b' => '',
+		'd' => '',
+	], Arrays::updateDiff($from, $toEmpty));
+
+
+	$toZero = ['a' => 0, 'b' => 0, 'c' => 0, 'd' => 0];
+	Assert::same([
+		'a' => 0,
+		'b' => 0,
+		'c' => 0,
+	], Arrays::updateDiff($from, $toZero));
+});

--- a/tests/Utils/Callback.invokeAll.phpt
+++ b/tests/Utils/Callback.invokeAll.phpt
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * Test: Nette\Utils\Callback::invokeAll()
+ */
+
+declare(strict_types=1);
+
+use Nette\Utils\Callback;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+class Test
+{
+	public function fn1(...$args)
+	{
+		return __METHOD__ . ' ' . implode(',', $args);
+	}
+
+
+	public function fn2(...$args)
+	{
+		return __METHOD__ . ' ' . implode(',', $args);
+	}
+}
+
+
+$list = [];
+$list[] = [new Test, 'fn1'];
+$list[] = [new Test, 'fn2'];
+
+Assert::same(
+	['Test::fn1 a,b', 'Test::fn2 a,b'],
+	Callback::invokeAll($list, 'a', 'b')
+);


### PR DESCRIPTION
- new feature
- BC break? no
- doc PR: will

Proposed `Arrays::updateDiff()` compares two associative arrays and returns such items from later one, which does not exist or differs from first one. By other words - which items have to be updated in first array, to be the same as second array.

As far as I know, there is no PHP function for that ([playground](https://3v4l.org/YW0CH)). For examle:
```php
$from = ['a' => null];
$to = ['a' => false];

# I didn't find a PHP function which returns
$diff = ['a' => false];
```

There are posible things to debate:
- function name
- arguments order
- recursive version
- objects comparing
- 3rd argument `callable $comparator = null`
