### PR TITLE
typo

### DIFF
--- a/src/Translator.php
+++ b/src/Translator.php
@@ -22,4 +22,4 @@ interface Translator
 }
 
 
-interface_exists(Nette\Localization\ITranslator::class);
+interface_exists(\Nette\Localization\ITranslator::class);


### PR DESCRIPTION
- bug fix
- BC break? no

I think there is missing backslash, so line 25 is triggering search of interface with FQN \Nette\Localization\Nette\Localization\ITranslator. In my project I am using only Latte and Utils. Autoloading is done by composer autoloader and after it is my second autoloader. My second autoloader tries to search for unexisting interface \Nette\Localization\Nette\Localization\ITranslator, because composer autoloader did not find such interface (I think it should be \Nette\Localization\ITranslator which is by composer autoload pointed to compatibility.php file).