### PR TITLE
FileSystem: fix createDir race condition

### DIFF
--- a/src/Utils/FileSystem.php
+++ b/src/Utils/FileSystem.php
@@ -25,8 +25,11 @@ final class FileSystem
 	 */
 	public static function createDir(string $dir, int $mode = 0777): void
 	{
-		if (!is_dir($dir) && !@mkdir($dir, $mode, true) && !is_dir($dir)) { // @ - dir may already exist
-			throw new Nette\IOException("Unable to create directory '$dir' with mode " . decoct($mode) . '. ' . Helpers::getLastError());
+		if (!is_dir($dir) && !@mkdir($dir, $mode, true)) { // @ - dir may already exist
+			clearstatcache(true, $dir);
+			if (!is_dir($dir)) {
+				throw new Nette\IOException("Unable to create directory '$dir' with mode " . decoct($mode) . '. ' . Helpers::getLastError());
+			}
 		}
 	}
 

--- a/src/Utils/FileSystem.php
+++ b/src/Utils/FileSystem.php
@@ -25,11 +25,9 @@ final class FileSystem
 	 */
 	public static function createDir(string $dir, int $mode = 0777): void
 	{
-		if (!is_dir($dir) && !@mkdir($dir, $mode, true)) { // @ - dir may already exist
-			clearstatcache(true, $dir);
-			if (!is_dir($dir)) {
-				throw new Nette\IOException("Unable to create directory '$dir' with mode " . decoct($mode) . '. ' . Helpers::getLastError());
-			}
+		// @ - dir may already exist
+		if (!is_dir($dir) && !@mkdir($dir, $mode, true) && !is_dir($dir) && ($lastError = Helpers::getLastError()) !== 'File exists') {
+			throw new Nette\IOException("Unable to create directory '$dir' with mode " . decoct($mode) . '. ' . $lastError);
 		}
 	}
 

--- a/src/Utils/FileSystem.php
+++ b/src/Utils/FileSystem.php
@@ -25,9 +25,11 @@ final class FileSystem
 	 */
 	public static function createDir(string $dir, int $mode = 0777): void
 	{
-		// @ - dir may already exist
-		if (!is_dir($dir) && !@mkdir($dir, $mode, true) && !is_dir($dir) && ($lastError = Helpers::getLastError()) !== 'File exists') {
-			throw new Nette\IOException("Unable to create directory '$dir' with mode " . decoct($mode) . '. ' . $lastError);
+		if (!is_dir($dir) && !@mkdir($dir, $mode, true)) { // @ - dir may already exist
+			clearstatcache(true);
+			if (!is_dir($dir)) {
+				throw new Nette\IOException("Unable to create directory '$dir' with mode " . decoct($mode) . '. ' . Helpers::getLastError());
+			}
 		}
 	}
 

--- a/src/Utils/FileSystem.php
+++ b/src/Utils/FileSystem.php
@@ -27,6 +27,7 @@ final class FileSystem
 	{
 		if (!is_dir($dir) && !@mkdir($dir, $mode, true)) { // @ - dir may already exist
 			clearstatcache(true);
+			usleep(1000);
 			if (!is_dir($dir)) {
 				throw new Nette\IOException("Unable to create directory '$dir' with mode " . decoct($mode) . '. ' . Helpers::getLastError());
 			}

--- a/src/Utils/FileSystem.php
+++ b/src/Utils/FileSystem.php
@@ -82,7 +82,10 @@ final class FileSystem
 		if (is_file($path) || is_link($path)) {
 			$func = DIRECTORY_SEPARATOR === '\\' && is_dir($path) ? 'rmdir' : 'unlink';
 			if (!@$func($path)) { // @ is escalated to exception
-				throw new Nette\IOException("Unable to delete '$path'. " . Helpers::getLastError());
+				clearstatcache(true);
+				if (is_file($path) || is_link($path)) {
+					throw new Nette\IOException("Unable to delete '$path'. " . Helpers::getLastError());
+				}
 			}
 
 		} elseif (is_dir($path)) {
@@ -90,7 +93,10 @@ final class FileSystem
 				static::delete($item->getPathname());
 			}
 			if (!@rmdir($path)) { // @ is escalated to exception
-				throw new Nette\IOException("Unable to delete directory '$path'. " . Helpers::getLastError());
+				clearstatcache(true);
+				if (is_dir($path)) {
+					throw new Nette\IOException("Unable to delete directory '$path'. " . Helpers::getLastError());
+				}
 			}
 		}
 	}


### PR DESCRIPTION
- bug fix
- BC break? no

I recently started testing code in parallel and builds started failing with error [`Nette\IOException: Unable to create directory '/directory' with mode 777. File exists`](https://github.com/orisai/nette-console/runs/3191840764?check_suite_focus=true#step:15:20). File cannot be created because it exists. Apparently PHP does not clear file stat cache when `mkdir()` is called and we have to handle it ourself.

Note: `clearstatcache(true, $dir);` nor `clearstatcache()` are enough, for some reason only complete cache removal including all files and realpath cache works. Should not affect performance much because it is run only in case of this race condition. `clearstatcache(true)` is the only variant that with 10 runs didn't fail for me, other variants failed with 2 runs max.

Funny thing: phpunit, symfony, laravel and others do not handle that properly neither. 