### PR TITLE
Validators::isPhpIdentifier(): Value is always string.

### DIFF
--- a/src/Utils/Validators.php
+++ b/src/Utils/Validators.php
@@ -355,6 +355,6 @@ class Validators
 	 */
 	public static function isPhpIdentifier(string $value): bool
 	{
-		return is_string($value) && preg_match('#^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$#D', $value);
+		return preg_match('#^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$#D', $value) === 1;
 	}
 }


### PR DESCRIPTION
- bug fix
- BC break? no

Value is always string + preg_match should be strict.
