### PR TITLE
Validators: isNumeric support string number '1.'

### DIFF
--- a/src/Utils/Validators.php
+++ b/src/Utils/Validators.php
@@ -226,7 +226,7 @@ class Validators
 	 */
 	public static function isNumeric(mixed $value): bool
 	{
-		return is_float($value) || is_int($value) || (is_string($value) && preg_match('#^[+-]?[0-9]*[.]?[0-9]+$#D', $value));
+		return is_float($value) || is_int($value) || (is_string($value) && preg_match('#^[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)$#D', $value));
 	}
 
 

--- a/tests/Utils/Validators.isNumeric().phpt
+++ b/tests/Utils/Validators.isNumeric().phpt
@@ -19,6 +19,7 @@ test('Valid numbers by sting', function () {
 	Assert::true(Validators::isNumeric('-1'));
 	Assert::true(Validators::isNumeric('+1'));
 	Assert::true(Validators::isNumeric('.0'));
+	Assert::true(Validators::isNumeric('1.'));
 	Assert::true(Validators::isNumeric('01.10'));
 });
 

--- a/tests/Utils/Validators.isNumeric().phpt
+++ b/tests/Utils/Validators.isNumeric().phpt
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Test: Nette\Utils\Validators::isNumeric()
+ */
+
+declare(strict_types=1);
+
+use Nette\Utils\Validators;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+test('Valid numbers by sting', function () {
+	Assert::true(Validators::isNumeric('1.0'));
+	Assert::true(Validators::isNumeric('1'));
+	Assert::true(Validators::isNumeric('-1'));
+	Assert::true(Validators::isNumeric('+1'));
+	Assert::true(Validators::isNumeric('.0'));
+	Assert::true(Validators::isNumeric('01.10'));
+});
+
+
+test('Valid numbers by float', function () {
+	Assert::true(Validators::isNumeric(1.0));
+	Assert::true(Validators::isNumeric(.0));
+	Assert::true(Validators::isNumeric(1.));
+});
+
+
+test('Valid numbers by int', function () {
+	Assert::true(Validators::isNumeric(1));
+	Assert::true(Validators::isNumeric(-1));
+	Assert::true(Validators::isNumeric(+1));
+});
+
+
+test('Invalid numbers', function () {
+	Assert::false(Validators::isNumeric('.')); // it is not 0.0
+	Assert::false(Validators::isNumeric(' 1'));
+	Assert::false(Validators::isNumeric('1 '));
+	Assert::false(Validators::isNumeric('- 1'));
+});


### PR DESCRIPTION
- bug fix
- BC break? no

The goal of this change is same behavior for float and string number.

### Old behavior
```php
Validators::isNumeric(1.); // float number true
Validators::isNumeric('1.'); // string number false
```
### New behavior
```php
Validators::isNumeric(1.); // float number true
Validators::isNumeric('1.'); // string number true
```

And I wrote test for to keep back compatibility. How you can see in three commits.

