### PR TITLE
Add getIntlDateFormat method in Datetime class

### DIFF
--- a/src/Utils/DateTime.php
+++ b/src/Utils/DateTime.php
@@ -144,4 +144,22 @@ class DateTime extends \DateTime implements \JsonSerializable
 		$dolly = clone $this;
 		return $modify ? $dolly->modify($modify) : $dolly;
 	}
+
+
+	public static function getIntlDateFormat(
+		$format = 'yyyy-MM-dd HH:mm:ss',
+		$time = null,
+		$locale = 'en_GB',
+		$timeZone = 'Europe/London'
+	): string {
+		if (empty($time)) {
+			$time = new \DateTime;
+		}
+
+		$formatter = new \IntlDateFormatter("{$locale}", \IntlDateFormatter::FULL, \IntlDateFormatter::FULL, $timeZone, \IntlDateFormatter::TRADITIONAL);
+
+		$formatter->setPattern($format);
+
+		return $formatter->format($time);
+	}
 }

--- a/src/Utils/DateTime.php
+++ b/src/Utils/DateTime.php
@@ -146,9 +146,8 @@ class DateTime extends \DateTime implements \JsonSerializable
 	}
 
 
-	public static function getIntlDateFormat(
+	public function getIntlDateFormat(
 		$format = 'yyyy-MM-dd HH:mm:ss',
-		$time = null,
 		$locale = 'en_GB',
 		$timeZone = 'Europe/London'
 	): string {
@@ -156,10 +155,16 @@ class DateTime extends \DateTime implements \JsonSerializable
 			$time = new \DateTime;
 		}
 
-		$formatter = new \IntlDateFormatter("{$locale}", \IntlDateFormatter::FULL, \IntlDateFormatter::FULL, $timeZone, \IntlDateFormatter::TRADITIONAL);
+		$formatter = new \IntlDateFormatter(
+			"{$locale}",
+			\IntlDateFormatter::FULL,
+			\IntlDateFormatter::FULL,
+			$timeZone,
+			\IntlDateFormatter::TRADITIONAL
+		);
 
 		$formatter->setPattern($format);
 
-		return $formatter->format($time);
+		return $formatter->format($this);
 	}
 }

--- a/tests/Utils/DateTime.getIntlDateFormat.phpt
+++ b/tests/Utils/DateTime.getIntlDateFormat.phpt
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Test: Nette\Utils\DateTime::getIntlDateFormat().
+ */
+
+declare(strict_types=1);
+
+use Nette\Utils\DateTime;
+use Tester\Assert;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+date_default_timezone_set('Europe/Prague');
+
+Assert::same(DateTime::getIntlDateFormat(
+	$format = 'LLLL YYYY HH:mm:ss',
+	$time = DateTime('2021-02-01 15:47:21'),
+	$locale = 'cs_CZ',
+	$timeZone = 'Europe/Prague'
+), 'únor 2021 15:47:21');

--- a/tests/Utils/DateTime.getIntlDateFormat.phpt
+++ b/tests/Utils/DateTime.getIntlDateFormat.phpt
@@ -14,9 +14,9 @@ require __DIR__ . '/../bootstrap.php';
 
 date_default_timezone_set('Europe/Prague');
 
-Assert::same(DateTime::getIntlDateFormat(
+$date = new DateTime('2021-02-01 15:47:21');
+Assert::same($date->getIntlDateFormat(
 	$format = 'LLLL YYYY HH:mm:ss',
-	$time = DateTime('2021-02-01 15:47:21'),
 	$locale = 'cs_CZ',
 	$timeZone = 'Europe/Prague'
 ), 'únor 2021 15:47:21');


### PR DESCRIPTION
- new feature? yes
- BC break? no
- doc PR: nette/docs# I can prepare if PR will be merged

In Nette Utils I didn't find method which I could replace deprecated PHP function `strftime('%B', $datetime->getTimestamp()),` which I used to Czech translation of munth.

I found solution at https://stackoverflow.com/a/46275845/6346869