### PR TITLE
ArrayList support returning references

### DIFF
--- a/src/Utils/ArrayList.php
+++ b/src/Utils/ArrayList.php
@@ -43,9 +43,12 @@ class ArrayList implements \ArrayAccess, \Countable, \IteratorAggregate
 	 * Returns an iterator over all items.
 	 * @return \ArrayIterator<int, T>
 	 */
-	public function getIterator(): \ArrayIterator
+	public function &getIterator(): \Iterator
 	{
-		return new \ArrayIterator($this->list);
+		foreach ($this->list as &$item) {
+		    yield $item;
+		}
+		unset($item);
 	}
 
 


### PR DESCRIPTION
$arrayList = ArrayList::form([['id'=>1],['id'=>2]]);
        // $arrayList => [['id'=>1],['id'=>2]]
        foreach($arrayList as &$item)
        {
            $item['id'] += 1;
        }
        unset($item);
        // $arrayList => [['id'=>2],['id'=>3]]

- bug fix / new feature?   <!-- #issue numbers, if any -->
- BC break? yes/no
- doc PR: nette/docs#???  <!-- highly welcome, see https://nette.org/en/writing -->

<!--
Describe your changes here to communicate to the maintainers why we should accept this pull request.

Please add new tests to show the fix or feature works. And take a moment to read the contributing guide https://nette.org/en/contributing

Thanks for contributing to Nette!
-->
