### PR TITLE
ArrayList support returning references 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
 		"jetbrains/phpstorm-attributes": "dev-master"
 	},
 	"conflict": {
-		"nette/finder": "<3"
+		"nette/finder": "<3",
+		"nette/schema": "<1.2.2"
 	},
 	"suggest": {
 		"ext-iconv": "to use Strings::webalize(), toAscii(), chr() and reverse()",

--- a/src/Utils/ArrayList.php
+++ b/src/Utils/ArrayList.php
@@ -43,9 +43,12 @@ class ArrayList implements \ArrayAccess, \Countable, \IteratorAggregate
 	 * Returns an iterator over all items.
 	 * @return \ArrayIterator<int, T>
 	 */
-	public function getIterator(): \ArrayIterator
+	public function &getIterator(): \Iterator
 	{
-		return new \ArrayIterator($this->list);
+		foreach ($this->list as &$item) {
+		    yield $item;
+		}
+		unset($item);
 	}
 
 

--- a/src/Utils/Type.php
+++ b/src/Utils/Type.php
@@ -64,17 +64,12 @@ final class Type
 	 */
 	public static function fromString(string $type): self
 	{
-		if (!preg_match('#(?:
-			\?([\w\\\\]+) |
-			(?: [\w\\\\]+  |  \( [\w\\\\]+ (?:&[\w\\\\]+)+ \) )  (?: \|  (?: [\w\\\\]+  |  \( [\w\\\\]+ (?:&[\w\\\\]+)+ \) ) )* |
-			[\w\\\\]+ (?:&[\w\\\\]+)+
-		)()$#xAD', $type, $m)) {
+		if (!self::isValid($type)) {
 			throw new Nette\InvalidArgumentException("Invalid type '$type'.");
 		}
 
-		[, $nullable] = $m;
-		if ($nullable) {
-			return new self([$nullable, 'null']);
+		if ($type[0] === '?') {
+			return new self([substr($type, 1), 'null']);
 		}
 
 		$unions = [];
@@ -86,6 +81,19 @@ final class Type
 		return count($unions) === 1 && $unions[0] instanceof self
 			? $unions[0]
 			: new self($unions);
+	}
+
+
+	/**
+	 * Checks whether the given type is syntactically valid.
+	 */
+	public static function isValid(string $type): bool
+	{
+		return (bool) preg_match('#(?:
+			\?([\w\\\\]+) |
+			(?: [\w\\\\]+  |  \( [\w\\\\]+ (?:&[\w\\\\]+)+ \) )  (?: \|  (?: [\w\\\\]+  |  \( [\w\\\\]+ (?:&[\w\\\\]+)+ \) ) )* |
+			[\w\\\\]+ (?:&[\w\\\\]+)+
+		)$#xAD', $type);
 	}
 
 

--- a/src/Utils/Validators.php
+++ b/src/Utils/Validators.php
@@ -25,10 +25,6 @@ class Validators
 		'never' => 1,
 	];
 
-	private const ClassKeywords = [
-		'self' => 1, 'parent' => 1, 'static' => 1,
-	];
-
 	/** @var array<string,?callable> */
 	protected static $validators = [
 		// PHP types
@@ -320,13 +316,13 @@ class Validators
 		$atom = "[-a-z0-9!#$%&'*+/=?^_`{|}~]"; // RFC 5322 unquoted characters in local-part
 		$alpha = "a-z\x80-\xFF"; // superset of IDN
 		return (bool) preg_match(<<<XX
-		(^
-			("([ !#-[\\]-~]*|\\\\[ -~])+"|$atom+(\\.$atom+)*)  # quoted or unquoted
-			@
-			([0-9$alpha]([-0-9$alpha]{0,61}[0-9$alpha])?\\.)+  # domain - RFC 1034
-			[$alpha]([-0-9$alpha]{0,17}[$alpha])?              # top domain
-		$)Dix
-		XX, $value);
+			(^
+				("([ !#-[\\]-~]*|\\\\[ -~])+"|$atom+(\\.$atom+)*)  # quoted or unquoted
+				@
+				([0-9$alpha]([-0-9$alpha]{0,61}[0-9$alpha])?\\.)+  # domain - RFC 1034
+				[$alpha]([-0-9$alpha]{0,17}[$alpha])?              # top domain
+			$)Dix
+			XX, $value);
 	}
 
 
@@ -337,19 +333,19 @@ class Validators
 	{
 		$alpha = "a-z\x80-\xFF";
 		return (bool) preg_match(<<<XX
-		(^
-			https?://(
-				(([-_0-9$alpha]+\\.)*                       # subdomain
-					[0-9$alpha]([-0-9$alpha]{0,61}[0-9$alpha])?\\.)?  # domain
-					[$alpha]([-0-9$alpha]{0,17}[$alpha])?   # top domain
-				|\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}  # IPv4
-				|\\[[0-9a-f:]{3,39}\\]                      # IPv6
-			)(:\\d{1,5})?                                   # port
-			(/\\S*)?                                        # path
-			(\\?\\S*)?                                      # query
-			(\\#\\S*)?                                      # fragment
-		$)Dix
-		XX, $value);
+			(^
+				https?://(
+					(([-_0-9$alpha]+\\.)*                       # subdomain
+						[0-9$alpha]([-0-9$alpha]{0,61}[0-9$alpha])?\\.)?  # domain
+						[$alpha]([-0-9$alpha]{0,17}[$alpha])?   # top domain
+					|\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}  # IPv4
+					|\\[[0-9a-f:]{3,39}\\]                      # IPv6
+				)(:\\d{1,5})?                                   # port
+				(/\\S*)?                                        # path
+				(\\?\\S*)?                                      # query
+				(\\#\\S*)?                                      # fragment
+			$)Dix
+			XX, $value);
 	}
 
 
@@ -394,6 +390,6 @@ class Validators
 	 */
 	public static function isClassKeyword(string $name): bool
 	{
-		return isset(self::ClassKeywords[strtolower($name)]);
+		return (bool) preg_match('#^(self|parent|static)$#Di', $name);
 	}
 }

--- a/tests/Utils/Type.isValid.phpt
+++ b/tests/Utils/Type.isValid.phpt
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Test: Nette\Utils\Type
+ */
+
+declare(strict_types=1);
+
+use Nette\Utils\Type;
+use Tester\Assert;
+
+require __DIR__ . '/../bootstrap.php';
+
+
+Assert::true(Type::isValid('string'));
+Assert::true(Type::isValid('?string'));
+Assert::true(Type::isValid('string|null'));
+Assert::true(Type::isValid('(A&B&C)'));
+Assert::true(Type::isValid('A&B&C'));
+Assert::true(Type::isValid('(A&C)|(C&D)|true'));
+
+Assert::false(Type::isValid('?string|null'));
+Assert::false(Type::isValid('?'));
+Assert::false(Type::isValid(''));
+Assert::false(Type::isValid('|foo'));
+Assert::false(Type::isValid('(A|B)'));
+Assert::false(Type::isValid('A&B|C'));


### PR DESCRIPTION
~~~php
$arrayList = ArrayList::form([['id'=>1],['id'=>2]]);
// $arrayList => [['id'=>1],['id'=>2]]
foreach($arrayList as &$item)
{
    $item['id'] += 1;
}
unset($item);
// $arrayList => [['id'=>2],['id'=>3]]

~~~
<!--
Describe your changes here to communicate to the maintainers why we should accept this pull request.

Please add new tests to show the fix or feature works. And take a moment to read the contributing guide https://nette.org/en/contributing

Thanks for contributing to Nette!
-->
