### PR TITLE
DateTime: Fix type error - modifyClone

### DIFF
--- a/src/Utils/DateTime.php
+++ b/src/Utils/DateTime.php
@@ -129,12 +129,23 @@ class DateTime extends \DateTime implements \JsonSerializable
 	}
 
 
+	public function modify(string $modifier = ''): static
+	{
+		$datetime = @parent::modify($modifier);
+
+		if ($datetime === false) {
+			throw new Nette\InvalidArgumentException("Failed to parse time string '$modifier'");
+		}
+		return $datetime;
+	}
+
+
 	/**
 	 * Creates a copy with a modified time.
 	 */
 	public function modifyClone(string $modify = ''): static
 	{
 		$dolly = clone $this;
-		return $modify ? (@$dolly->modify($modify) ?: $dolly) : $dolly;
+		return $modify ? $dolly->modify($modify) : $dolly;
 	}
 }

--- a/src/Utils/DateTime.php
+++ b/src/Utils/DateTime.php
@@ -135,6 +135,6 @@ class DateTime extends \DateTime implements \JsonSerializable
 	public function modifyClone(string $modify = ''): static
 	{
 		$dolly = clone $this;
-		return $modify ? $dolly->modify($modify) : $dolly;
+		return $modify ? (@$dolly->modify($modify) ?: $dolly) : $dolly;
 	}
 }

--- a/tests/Utils/DateTime.modifyClone.phpt
+++ b/tests/Utils/DateTime.modifyClone.phpt
@@ -26,9 +26,7 @@ Assert::type(DateTime::class, $dolly2);
 Assert::notSame($date, $dolly2);
 Assert::notSame((string) $date, (string) $dolly2);
 
-
-$dolly3 = $date->modifyClone('xx');
-Assert::type(DateTime::class, $dolly3);
-Assert::notSame($date, $dolly3);
-Assert::equal($date, $dolly3);
-Assert::same((string) $date, (string) $dolly3);
+Assert::exception(
+	fn() => $date->modifyClone('xx'),
+	Nette\InvalidArgumentException::class,
+);

--- a/tests/Utils/DateTime.modifyClone.phpt
+++ b/tests/Utils/DateTime.modifyClone.phpt
@@ -25,3 +25,10 @@ $dolly2 = $date->modifyClone('+1 hour');
 Assert::type(DateTime::class, $dolly2);
 Assert::notSame($date, $dolly2);
 Assert::notSame((string) $date, (string) $dolly2);
+
+
+$dolly3 = $date->modifyClone('xx');
+Assert::type(DateTime::class, $dolly3);
+Assert::notSame($date, $dolly3);
+Assert::equal($date, $dolly3);
+Assert::same((string) $date, (string) $dolly3);


### PR DESCRIPTION
- bug fix 
- BC break? yes/no?

I have a problem with `Nette\Utils\DateTime`. I use `modifyClone` method:

```php
$date = new Nette\Utils\DateTime('now');

$date->modifyClone('xx'); // Invalid date string
```

And this cause the error:

` TypeError: Nette\Utils\DateTime::modifyClone(): Return value must be of type Nette\Utils\DateTime, bool returned`

because `DateTime::modify` returns `DateTime|false` and Warning:

`E_WARNING: DateTime::modify(): Failed to parse time string (xx) at position 0 (x): The timezone could not be found in the database`

We can solve it by that object will only cloned like that:

```php
	public function modifyClone(string $modify = ''): static
	{
		$dolly = clone $this;
		return $modify ? (@$dolly->modify($modify) ?: $dolly) : $dolly;
	}
```

or we can throw an exception:

```php
	public function modifyClone(string $modify = ''): static
	{
		$dolly = clone $this;
		
		$dolly = @$dolly->modify($modify);
		if ($dolly === false) {
			throw new \Exception('Failed to parse time string');
		}
		return $dolly;
	}
```

What do you think?