### PR TITLE
Avoid deprecation notice when using utf8_decode 

### DIFF
--- a/src/Utils/Strings.php
+++ b/src/Utils/Strings.php
@@ -401,9 +401,9 @@ class Strings
 			throw new Nette\NotSupportedException(__METHOD__ . '() requires ICONV or MBSTRING extensions, but none of them is loaded.');
 		}
 
-		return match(true): {
-			function_exists('mb_strlen'): mb_strlen($s, 'UTF-8');
-			function_exists('iconv_strlen'): iconv_strlen($s, 'UTF-8');
+		return match(true) {
+			function_exists('mb_strlen') => mb_strlen($s, 'UTF-8'),
+			function_exists('iconv_strlen') => iconv_strlen($s, 'UTF-8'),
 		};
 	}
 

--- a/src/Utils/Strings.php
+++ b/src/Utils/Strings.php
@@ -397,9 +397,14 @@ class Strings
 	 */
 	public static function length(string $s): int
 	{
-		return function_exists('mb_strlen')
-			? mb_strlen($s, 'UTF-8')
-			: strlen(utf8_decode($s));
+		if (!extension_loaded('iconv') && !extension_loaded('mbstring')) {
+			throw new Nette\NotSupportedException(__METHOD__ . '() requires ICONV or MBSTRING extensions, but none of them is loaded.');
+		}
+
+		return match(true): {
+			function_exists('mb_strlen'): mb_strlen($s, 'UTF-8');
+			function_exists('iconv_strlen'): iconv_strlen($s, 'UTF-8');
+		};
 	}
 
 


### PR DESCRIPTION
- bug fix
- BC break? no

PHP 8.2 throws deprecation notice on `utf8_encode` and `utf8_decode` functions. `Strings::length` used `utf8_decode` to determine correct length of string - using `mb_strlen`, or natively using `utf8_decode`. I refactored this function to use `mbstring` or `iconv` extensions to determine correct length.

User can no longer run `Strings::length()` function without at least one of these extensions, however since they are super common extensions I dont see this as s problem nowadays