### PR TITLE
DateTime: build from timestamp use method setTimestamp()

### DIFF
--- a/src/Utils/DateTime.php
+++ b/src/Utils/DateTime.php
@@ -52,7 +52,7 @@ class DateTime extends \DateTime implements \JsonSerializable
 				$time += time();
 			}
 
-			return (new static('@' . $time))->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+			return (new static())->setTimestamp($time);
 
 		} else { // textual or null
 			return new static((string) $time);


### PR DESCRIPTION
-  new feature?  no, only update
- BC break? no
- doc PR: nette/docs#???  not need


- keep right timezone
- compact syntax
- little bit faster, let's try

### Test how I measure
```php
function measure(callable $test): float
{
	$start = microtime(true);
	for ($i = 0; $i < 1000; ++$i) {
		$test($i);
	}
	return microtime(true) - $start;
}

echo 'Datetime' . PHP_EOL;
echo measure(static function (int $i) {
		return (new DateTime())->setTimestamp($i);
	}) . PHP_EOL;

echo measure(static function (int $i) {
		return (new DateTime('@' . $i))->setTimezone(new \DateTimeZone(date_default_timezone_get()));
	}) . PHP_EOL;

echo 'DatetimeImmutable' . PHP_EOL;
echo measure(static function (int $i) {
		return (new DateTimeImmutable())->setTimestamp($i);
	}) . PHP_EOL;

echo measure(static function (int $i) {
		return (new DateTimeImmutable('@' . $i))->setTimezone(new \DateTimeZone(date_default_timezone_get()));
	}) . PHP_EOL;
```
