### PR TITLE
DateTime: method setTime() allow null value for keep current value

### DIFF
--- a/src/Utils/DateTime.php
+++ b/src/Utils/DateTime.php
@@ -111,6 +111,22 @@ class DateTime extends \DateTime implements \JsonSerializable
 	}
 
 
+	public function setTime(
+		?int $hour,
+		?int $minute,
+		?int $second = 0,
+		?int $microsecond = 0,
+	): static
+	{
+		return parent::setTime(
+			$hour ?? (int) $this->format('G'),
+			$minute ?? (int) $this->format('i'),
+			$second ?? (int) $this->format('s'),
+			$microsecond ?? (int) $this->format('u'),
+		);
+	}
+
+
 	/**
 	 * Returns JSON representation in ISO 8601 (used by JavaScript).
 	 */

--- a/tests/Utils/DateTime.setTime.phpt
+++ b/tests/Utils/DateTime.setTime.phpt
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Test: Nette\Utils\DateTime::setTime().
+ */
+
+declare(strict_types=1);
+
+use Nette\Utils\DateTime;
+use Tester\Assert;
+
+require __DIR__ . '/../bootstrap.php';
+
+date_default_timezone_set('Europe/Prague');
+
+Assert::same('00:00:00.000000', (new DateTime('2050-08-13 12:40:50.86'))->setTime(0, 0)->format('H:i:s.u'));
+Assert::same('12:00:00.000000', (new DateTime('2050-08-13 12:40:50.86'))->setTime(null, 0)->format('H:i:s.u'));
+Assert::same('00:40:00.000000', (new DateTime('2050-08-13 12:40:50.86'))->setTime(0, null)->format('H:i:s.u'));
+Assert::same('00:00:50.000000', (new DateTime('2050-08-13 12:40:50.86'))->setTime(0, 0, null)->format('H:i:s.u'));
+Assert::same('00:00:00.860000', (new DateTime('2050-08-13 12:40:50.86'))->setTime(0, 0, 0, null)->format('H:i:s.u'));
+Assert::same('12:40:50.860000', (new DateTime('2050-08-13 12:40:50.86'))->setTime(null, null, null, null)->format('H:i:s.u'));


### PR DESCRIPTION
- new feature?  yes
- BC break? no
- doc PR: nette/docs#???  if you agree with theses changes I will write.

I keep default values like a parent. The back compatibility is ok.

You can more simply modify part of time. For example you want reset microseconds

```php
dump((new Nette\Utils\DateTime())->setTime(null, null, null, 0));
```

More examples are in test.