### PR TITLE
Function ReflectionType::__toString() is deprecated

### DIFF
--- a/src/Utils/Reflection.php
+++ b/src/Utils/Reflection.php
@@ -39,7 +39,7 @@ class Reflection
 	public static function getReturnType(\ReflectionFunctionAbstract $func)
 	{
 		return PHP_VERSION_ID >= 70000 && $func->hasReturnType()
-			? self::normalizeType((string) $func->getReturnType(), $func)
+			? self::normalizeType(@ (string) $func->getReturnType(), $func)
 			: null;
 	}
 
@@ -51,7 +51,7 @@ class Reflection
 	{
 		if (PHP_VERSION_ID >= 70000) {
 			return $param->hasType()
-				? self::normalizeType((string) $param->getType(), $param)
+				? self::normalizeType(@ (string) $param->getType(), $param)
 				: null;
 		} elseif ($param->isArray() || $param->isCallable()) {
 			return $param->isArray() ? 'array' : 'callable';


### PR DESCRIPTION
- bug fix
- BC break? no

In php7.4 version it Function ReflectionType::__toString() is deprecated. It breaks my projects that I would like to keep on php7.4.

<!--
Please use the latest released version (ie. last tagged commit) as a base for PR.

Describe your changes here to communicate to the maintainers why we should accept this pull request.

Please add new tests to show the fix or feature works. And take a moment to read the contributing guide https://nette.org/en/contributing

Thanks for contributing to Nette!
-->
