### PR TITLE
Strings improvement: trim ZWSP char

### DIFF
--- a/src/Utils/Strings.php
+++ b/src/Utils/Strings.php
@@ -21,7 +21,7 @@ class Strings
 {
 	use Nette\StaticClass;
 
-	public const TrimCharacters = " \t\n\r\0\x0B\u{A0}";
+	public const TrimCharacters = " \t\n\r\0\x0B\u{A0}\u{200B}";
 
 	/** @deprecated use Strings::TrimCharacters */
 	public const TRIM_CHARACTERS = self::TrimCharacters;

--- a/tests/Utils/Strings.trim().phpt
+++ b/tests/Utils/Strings.trim().phpt
@@ -17,7 +17,7 @@ Assert::same('x', Strings::trim(" \t\n\r\x00\x0B\u{A0}x"));
 Assert::same('a b', Strings::trim(' a b '));
 Assert::same(' a b ', Strings::trim(' a b ', ''));
 Assert::same('e', Strings::trim("\u{158}e-", "\u{158}-")); // Ře-
-Assert::same('foo', Strings::trim("​foo"));
+Assert::same('foo', Strings::trim("​foo")); // Contains \u{200B} - `ZWSPfoo`
 
 Assert::exception(
 	fn() => Strings::trim("\xC2x\xA0"),

--- a/tests/Utils/Strings.trim().phpt
+++ b/tests/Utils/Strings.trim().phpt
@@ -17,6 +17,7 @@ Assert::same('x', Strings::trim(" \t\n\r\x00\x0B\u{A0}x"));
 Assert::same('a b', Strings::trim(' a b '));
 Assert::same(' a b ', Strings::trim(' a b ', ''));
 Assert::same('e', Strings::trim("\u{158}e-", "\u{158}-")); // Ře-
+Assert::same('foo', Strings::trim("​foo"));
 
 Assert::exception(
 	fn() => Strings::trim("\xC2x\xA0"),


### PR DESCRIPTION
- new feature
- BC break? yes - if someone relies on having ZWSP non-trimmed while using default parameter.
- doc PR: Not needed, function is covered and does not mention the default characters

Sneaky [Zero-Width Space char \u{200B}](https://www.fileformat.info/info/unicode/char/200b/index.htm) is currently untrimmed by `trim` function, while I'd expect it to do so.

Workaround:
1. Fork or extend the class and overwrite default param
2. Manually set updated charlist as second argument to every `trim()` call

