### PR TITLE
Added Arrays::find() method

### DIFF
--- a/src/Utils/Arrays.php
+++ b/src/Utils/Arrays.php
@@ -460,4 +460,26 @@ class Arrays
 
 		return $res;
 	}
+
+
+	/**
+	 * Returns the first item from the array which passes the test implemented by the
+	 * provided function. The provided function has the signature
+	 * `function ($value, $key, array $array): bool`. If no match was found, it returns null.
+	 * @template K
+	 * @template V
+	 * @param  iterable<K, V> $array
+	 * @param  callable(V, K, ($array is array ? array<K, V> : iterable<K, V>)): bool $callback
+	 * @return ?V
+	 */
+	public static function find(iterable $array, callable $callback): mixed
+	{
+		foreach ($array as $k => $v) {
+			if ($callback($v, $k, $array)) {
+				return $v;
+			}
+		}
+
+		return null;
+	}
 }

--- a/tests/Utils/Arrays.find().phpt
+++ b/tests/Utils/Arrays.find().phpt
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use Nette\Utils\Arrays;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+test('', function () {
+	$arr = [];
+	$log = [];
+	$res = Arrays::find(
+		$arr,
+		function ($v, $k, $arr) use (&$log) {
+			$log[] = func_get_args();
+			return false;
+		},
+	);
+	Assert::same(null, $res);
+	Assert::same([], $log);
+});
+
+test('', function () {
+	$arr = ['a', 'b', 'c'];
+	$log = [];
+	$res = Arrays::find(
+		$arr,
+		function ($v, $k, $arr) use (&$log) {
+			$log[] = func_get_args();
+			return $v === 'b';
+		},
+	);
+	Assert::same('b', $res);
+	Assert::same([['a', 0, $arr], ['b', 1, $arr]], $log);
+});
+
+test('', function () {
+	$arr = ['a', 'b', 'c'];
+	$log = [];
+	$res = Arrays::find(
+		$arr,
+		function ($v, $k, $arr) use (&$log) {
+			$log[] = func_get_args();
+			return false;
+		},
+	);
+	Assert::same(null, $res);
+	Assert::same([['a', 0, $arr], ['b', 1, $arr], ['c', 2, $arr]], $log);
+});


### PR DESCRIPTION
- new feature
- BC break? no
- doc PR: https://github.com/nette/docs/pull/1035

This PR adds the Arrays::find() helper. It's somewhat commonly used functionality and often inconvenient and unnecessarily verbose in raw PHP.