### PR TITLE
FileSystem: add resolvePath

### DIFF
--- a/src/Iterators/Mapper.php
+++ b/src/Iterators/Mapper.php
@@ -10,9 +10,8 @@ declare(strict_types=1);
 namespace Nette\Iterators;
 
 
-
 /**
- * Applies the callback to the elements of the inner iterator.
+ * @deprecated use Nette\Utils\Iterables::map()
  */
 class Mapper extends \IteratorIterator
 {

--- a/src/Utils/Arrays.php
+++ b/src/Utils/Arrays.php
@@ -369,11 +369,11 @@ class Arrays
 
 	/**
 	 * Tests whether at least one element in the array passes the test implemented by the provided function,
-	 * which has the signature `function ($value, $key, array $array): bool`.
-	 * @template K
+	 * which has the signature `function (mixed $value, int|string $key, array $array): bool`.
+	 * @template K of array-key
 	 * @template V
-	 * @param  iterable<K, V> $array
-	 * @param  callable(V, K, ($array is array ? array<K, V> : iterable<K, V>)): bool $predicate
+	 * @param  array<K, V> $array
+	 * @param  callable(V, K, array<K, V>): bool $predicate
 	 */
 	public static function some(iterable $array, callable $predicate): bool
 	{
@@ -389,11 +389,11 @@ class Arrays
 
 	/**
 	 * Tests whether all elements in the array pass the test implemented by the provided function,
-	 * which has the signature `function ($value, $key, array $array): bool`.
-	 * @template K
+	 * which has the signature `function (mixed $value, int|string $key, array $array): bool`.
+	 * @template K of array-key
 	 * @template V
-	 * @param  iterable<K, V> $array
-	 * @param  callable(V, K, ($array is array ? array<K, V> : iterable<K, V>)): bool $predicate
+	 * @param  array<K, V> $array
+	 * @param  callable(V, K, array<K, V>): bool $predicate
 	 */
 	public static function every(iterable $array, callable $predicate): bool
 	{
@@ -430,12 +430,12 @@ class Arrays
 
 	/**
 	 * Returns an array containing the original keys and results of applying the given transform function to each element.
-	 * The function has signature `function ($value, $key, array $array): mixed`.
+	 * The function has signature `function (mixed $value, int|string $key, array $array): mixed`.
 	 * @template K of array-key
 	 * @template V
 	 * @template R
-	 * @param  iterable<K, V> $array
-	 * @param  callable(V, K, ($array is array ? array<K, V> : iterable<K, V>)): R $transformer
+	 * @param  array<K, V> $array
+	 * @param  callable(V, K, array<K, V>): R $transformer
 	 * @return array<K, R>
 	 */
 	public static function map(iterable $array, callable $transformer): array

--- a/src/Utils/Callback.php
+++ b/src/Utils/Callback.php
@@ -94,7 +94,9 @@ final class Callback
 		}
 
 		if (is_string($callable) && str_contains($callable, '::')) {
-			return new ReflectionMethod($callable);
+			return PHP_VERSION_ID < 80300
+				? new ReflectionMethod($callable)
+				: ReflectionMethod::createFromMethodName($callable);
 		} elseif (is_array($callable)) {
 			return new ReflectionMethod($callable[0], $callable[1]);
 		} elseif (is_object($callable) && !$callable instanceof \Closure) {

--- a/src/Utils/FileSystem.php
+++ b/src/Utils/FileSystem.php
@@ -305,6 +305,18 @@ final class FileSystem
 	}
 
 
+	public static function resolvePath(string ...$paths): string
+	{
+		for ($i = count($paths) - 1; $i >= 0; $i--) {
+			if (self::isAbsolute($paths[$i])) {
+				return self::joinPaths(...array_slice($paths, $i));
+			}
+		}
+
+		return self::joinPaths(getcwd(), ...$paths);
+	}
+
+
 	/**
 	 * Converts backslashes to slashes.
 	 */

--- a/src/Utils/Reflection.php
+++ b/src/Utils/Reflection.php
@@ -100,7 +100,7 @@ final class Reflection
 
 		$hash = [$method->getFileName(), $method->getStartLine(), $method->getEndLine()];
 		if (($alias = $decl->getTraitAliases()[$method->name] ?? null)
-			&& ($m = new \ReflectionMethod($alias))
+			&& ($m = PHP_VERSION_ID < 80300 ? new \ReflectionMethod($alias) : \ReflectionMethod::createFromMethodName($alias))
 			&& $hash === [$m->getFileName(), $m->getStartLine(), $m->getEndLine()]
 		) {
 			return self::getMethodDeclaringMethod($m);

--- a/tests/Utils/FileSystem.resolvePath.phpt
+++ b/tests/Utils/FileSystem.resolvePath.phpt
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Nette\Utils\FileSystem;
+use Tester\Assert;
+
+
+require __DIR__ . '/../bootstrap.php';
+
+
+test('', function () {
+	$S = DIRECTORY_SEPARATOR;
+	$cwd = getcwd();
+	Assert::same($cwd, FileSystem::resolvePath());
+	Assert::same("{$S}foo{$S}bar", FileSystem::resolvePath('/foo', 'bar'));
+	Assert::same("{$S}foo{$S}bar{$S}baz", FileSystem::resolvePath('/foo', 'bar', 'baz'));
+	Assert::same("{$S}foo{$S}baz", FileSystem::resolvePath('/foo', 'bar/..', 'baz'));
+	Assert::same("{$S}bar{$S}baz", FileSystem::resolvePath('foo', '/bar', 'baz'));
+	Assert::same("{$cwd}{$S}foo{$S}bar{$S}baz", FileSystem::resolvePath('foo', 'bar', 'baz'));
+});


### PR DESCRIPTION
- new feature
- BC break: no

This a port of [path.resolve](https://nodejs.org/api/path.html#pathresolvepaths) from Node.js.

In reality I only need sth like

```php
public static function resolvePath(string $a, string $b): string
{
	return self::isAbsolute($b) ? $b : self::joinPaths($a, $b);
}
```

so I'm not sure how useful the more general implementation is.