### PR TITLE
Allow using null in addText, addHtml and insert; Closes #332

### DIFF
--- a/src/Utils/Html.php
+++ b/src/Utils/Html.php
@@ -573,7 +573,7 @@ class Html implements \ArrayAccess, \Countable, \IteratorAggregate, HtmlStringab
 	/**
 	 * Adds new element's child.
 	 */
-	final public function addHtml(HtmlStringable|string $child): static
+	final public function addHtml(HtmlStringable|string|null $child): static
 	{
 		return $this->insert(null, $child);
 	}
@@ -582,7 +582,7 @@ class Html implements \ArrayAccess, \Countable, \IteratorAggregate, HtmlStringab
 	/**
 	 * Appends plain-text string to element content.
 	 */
-	public function addText(\Stringable|string $text): static
+	public function addText(\Stringable|string|null $text): static
 	{
 		if (!$text instanceof HtmlStringable) {
 			$text = htmlspecialchars((string) $text, ENT_NOQUOTES, 'UTF-8');
@@ -605,7 +605,7 @@ class Html implements \ArrayAccess, \Countable, \IteratorAggregate, HtmlStringab
 	/**
 	 * Inserts child node.
 	 */
-	public function insert(?int $index, HtmlStringable|string $child, bool $replace = false): static
+	public function insert(?int $index, HtmlStringable|string|null $child, bool $replace = false): static
 	{
 		$child = $child instanceof self ? $child : (string) $child;
 		if ($index === null) { // append
@@ -622,7 +622,7 @@ class Html implements \ArrayAccess, \Countable, \IteratorAggregate, HtmlStringab
 	/**
 	 * Inserts (replaces) child node (\ArrayAccess implementation).
 	 * @param  int|null  $index  position or null for appending
-	 * @param  Html|string  $child  Html node or raw HTML string
+	 * @param  Html|string|null  $child  Html node or raw HTML string
 	 */
 	final public function offsetSet($index, $child): void
 	{

--- a/tests/Utils/Html.children.phpt
+++ b/tests/Utils/Html.children.phpt
@@ -87,3 +87,12 @@ test('cloning element with children preservation', function () {
 
 	Assert::same((string) $el, (string) $el2);
 });
+
+
+test('using null with addText and addHtml', function () {
+	$el = Html::el('div');
+	$el->addText(null);
+	$el->addHtml(null);
+
+	Assert::same((string) $el, '<div></div>');
+});


### PR DESCRIPTION
This is reintroducing back option to use null with Html::addText and Html::addHtml after switching from mixed type to narrower one.

- #332
- no (fixed bc break)