### PR TITLE
Use native `clamp` function inside util

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
 		}
 	],
 	"require": {
-		"php": "8.2 - 8.5"
+		"php": "8.2 - 8.5",
+		"symfony/polyfill-php86": "^1.36"
 	},
 	"require-dev": {
 		"nette/tester": "^2.5",

--- a/src/Utils/Helpers.php
+++ b/src/Utils/Helpers.php
@@ -65,11 +65,7 @@ class Helpers
 	 */
 	public static function clamp(int|float $value, int|float $min, int|float $max): int|float
 	{
-		if ($min > $max) {
-			throw new Nette\InvalidArgumentException("Minimum ($min) is not less than maximum ($max).");
-		}
-
-		return min(max($value, $min), $max);
+		return clamp($value, $min, $max);
 	}
 
 

--- a/tests/Utils/Helpers.clamp().phpt
+++ b/tests/Utils/Helpers.clamp().phpt
@@ -14,6 +14,6 @@ Assert::same(19.0, Helpers::clamp(20.0, 10.0, 19.0));
 
 Assert::exception(
 	fn() => Helpers::clamp(20, 30, 10),
-	InvalidArgumentException::class,
-	'Minimum (30) is not less than maximum (10).',
+	ValueError::class,
+	'clamp(): Argument #2 ($min) must be smaller than or equal to argument #3 ($max)',
 );


### PR DESCRIPTION
- new feature   <!-- #issue numbers, if any -->
- no (potentially?)
- doc PR: n/a  <!-- highly welcome, see https://nette.org/en/writing -->

<!--
Please use the latest released version (ie. last tagged commit) as a base for PR.

Describe your changes here to communicate to the maintainers why we should accept this pull request.

Please add new tests to show the fix or feature works. And take a moment to read the contributing guide https://nette.org/en/contributing

Thanks for contributing to Nette!
-->
This replaces the manual `clamp` implementation with the PHP native `clamp`, which is new in PHP 8.6 (unreleased). See also:
- https://wiki.php.net/rfc/clamp_v2
- https://github.com/php/php-src/pull/19434
- https://github.com/symfony/polyfill/pull/554

Note that the only behavioral change is the type of exception and corresponding message. Migrating towards the new PHP native one seems like a reasonable choice to me, but if preferable I'm fine with catching it and manually throwing the old one.