### PR TITLE
SmartObject: @property with whitespace or newlines inside the type is silently ignored

### DIFF
--- a/src/Utils/ObjectHelpers.php
+++ b/src/Utils/ObjectHelpers.php
@@ -131,7 +131,7 @@ final class ObjectHelpers
 
 		$rc = new \ReflectionClass($class);
 		preg_match_all(
-			'~^  [ \t*]*  @property(|-read|-write|-deprecated)  [ \t]+  [^\s$]+  [ \t]+  \$  (\w+)  ()~mx',
+			'~^  [ \t*]*  @property(|-read|-write|-deprecated)  [ \t]+  (?:(?!@)[^\s$*]+[\s*]+)++  \$  (\w+)  ()~mx',
 			(string) $rc->getDocComment(),
 			$matches,
 			PREG_SET_ORDER,

--- a/src/Utils/ObjectHelpers.php
+++ b/src/Utils/ObjectHelpers.php
@@ -30,7 +30,7 @@ final class ObjectHelpers
 		$rc = new \ReflectionClass($class);
 		$hint = self::getSuggestion(array_merge(
 			array_filter($rc->getProperties(\ReflectionProperty::IS_PUBLIC), fn($p) => !$p->isStatic()),
-			self::parseFullDoc($rc, '~^[ \t*]*@property(?:-read)?[ \t]+(?:\S+[ \t]+)??\$(\w+)~m'),
+			self::parseFullDoc($rc, '~^[ \t*]*@property(?:-read)?[ \t]+(?:(?!@)[^\s$*]+[\s*]+)*+\$(\w+)~m'),
 		), $name);
 		throw new MemberAccessException("Cannot read an undeclared property $class::\$$name" . ($hint ? ", did you mean \$$hint?" : '.'));
 	}
@@ -45,7 +45,7 @@ final class ObjectHelpers
 		$rc = new \ReflectionClass($class);
 		$hint = self::getSuggestion(array_merge(
 			array_filter($rc->getProperties(\ReflectionProperty::IS_PUBLIC), fn($p) => !$p->isStatic()),
-			self::parseFullDoc($rc, '~^[ \t*]*@property(?:-write)?[ \t]+(?:\S+[ \t]+)??\$(\w+)~m'),
+			self::parseFullDoc($rc, '~^[ \t*]*@property(?:-write)?[ \t]+(?:(?!@)[^\s$*]+[\s*]+)*+\$(\w+)~m'),
 		), $name);
 		throw new MemberAccessException("Cannot write to an undeclared property $class::\$$name" . ($hint ? ", did you mean \$$hint?" : '.'));
 	}

--- a/tests/Utils/ObjectHelpers.getMagicProperites().phpt
+++ b/tests/Utils/ObjectHelpers.getMagicProperites().phpt
@@ -16,6 +16,15 @@ require __DIR__ . '/../bootstrap.php';
  * @property int $getter2 by ref
  * @property int $setter
  * @property A\B $both with typehint
+ * @property array<string, string> $generic with space in type
+ * @property array<int, array<string, mixed>> $nested
+ * @property array{a: int, b?: string} $shape
+ * @property array{
+ *     multi: string,
+ *     line: int,
+ * } $multiline
+ * @property array<string,
+ *     int> $multilineGeneric
  * @property int $missing
  * @property int $Upper
  * @property int $cAse
@@ -27,6 +36,9 @@ require __DIR__ . '/../bootstrap.php';
  * @property-x int $invalid1
  * @property $invalid2
  * abc @property int $invalid3
+ * @property array{
+ *     unterminated: string,
+ * @property-read int $bridged
  */
 class TestClass
 {
@@ -51,6 +63,41 @@ class TestClass
 
 
 	public function setBoth()
+	{
+	}
+
+
+	public function getGeneric()
+	{
+	}
+
+
+	public function getNested()
+	{
+	}
+
+
+	public function getShape()
+	{
+	}
+
+
+	public function getMultiline()
+	{
+	}
+
+
+	public function getMultilineGeneric()
+	{
+	}
+
+
+	public function getBridged()
+	{
+	}
+
+
+	public function setBridged()
 	{
 	}
 
@@ -118,10 +165,16 @@ Assert::same([
 	'getter2' => 0b0101,
 	'setter' => 0b1000,
 	'both' => 0b1011,
+	'generic' => 0b0011,
+	'nested' => 0b0011,
+	'shape' => 0b0011,
+	'multiline' => 0b0011,
+	'multilineGeneric' => 0b0011,
 	'Upper' => 0b0011,
 	'protected' => 0b0011,
 	'read' => 0b0011,
 	'write' => 0b1000,
+	'bridged' => 0b0011,
 ], ObjectHelpers::getMagicProperties('TestClass'));
 
 

--- a/tests/Utils/ObjectHelpers.strictness.phpt
+++ b/tests/Utils/ObjectHelpers.strictness.phpt
@@ -143,3 +143,59 @@ Assert::exception(
 	MemberAccessException::class,
 	'Cannot read an undeclared property TestClass::$protectedX.',
 );
+
+
+// hints from @property annotations with whitespace inside the type
+/**
+ * @property array<string, string> $generic
+ * @property array{
+ *     foo: string,
+ * } $multiline
+ * @property-read array<int, string> $readOnly
+ * @property-write array<int, string> $writeOnly
+ */
+class AnnotatedClass
+{
+}
+
+Assert::exception(
+	fn() => ObjectHelpers::strictGet('AnnotatedClass', 'gneric'),
+	MemberAccessException::class,
+	'Cannot read an undeclared property AnnotatedClass::$gneric, did you mean $generic?',
+);
+
+Assert::exception(
+	fn() => ObjectHelpers::strictSet('AnnotatedClass', 'gneric'),
+	MemberAccessException::class,
+	'Cannot write to an undeclared property AnnotatedClass::$gneric, did you mean $generic?',
+);
+
+Assert::exception(
+	fn() => ObjectHelpers::strictGet('AnnotatedClass', 'multilin'),
+	MemberAccessException::class,
+	'Cannot read an undeclared property AnnotatedClass::$multilin, did you mean $multiline?',
+);
+
+Assert::exception(
+	fn() => ObjectHelpers::strictGet('AnnotatedClass', 'readOnli'),
+	MemberAccessException::class,
+	'Cannot read an undeclared property AnnotatedClass::$readOnli, did you mean $readOnly?',
+);
+
+Assert::exception(
+	fn() => ObjectHelpers::strictSet('AnnotatedClass', 'writeOnli'),
+	MemberAccessException::class,
+	'Cannot write to an undeclared property AnnotatedClass::$writeOnli, did you mean $writeOnly?',
+);
+
+Assert::exception(
+	fn() => ObjectHelpers::strictSet('AnnotatedClass', 'readOnli'),
+	MemberAccessException::class,
+	'Cannot write to an undeclared property AnnotatedClass::$readOnli.',
+);
+
+Assert::exception(
+	fn() => ObjectHelpers::strictGet('AnnotatedClass', 'writeOnli'),
+	MemberAccessException::class,
+	'Cannot read an undeclared property AnnotatedClass::$writeOnli.',
+);


### PR DESCRIPTION
- bug fix
- BC break? no

`ObjectHelpers::getMagicProperties()` does not recognize a `@property` annotation when the type contains whitespace, which is common with generics and array shapes. The properties are silently dropped and lead to member access exception at runtime. It bit me while adding types to an old codebase

Fixed regex now parses the types with newlines and whitespace properly and with no backtracking

I have also noticed the same issue in strictGet/strictSet, "did you mean" hint was missing. Fixed in second commit.