### PR TITLE
Validators: allow pipe character inside a `pattern:` regular expression

### DIFF
--- a/src/Utils/Validators.php
+++ b/src/Utils/Validators.php
@@ -137,7 +137,9 @@ class Validators
 	 */
 	public static function is(mixed $value, string $expected): bool
 	{
-		foreach (explode('|', $expected) as $item) {
+		$items = explode('|', $expected);
+		for ($i = 0, $count = count($items); $i < $count; $i++) {
+			$item = $items[$i];
 			if (str_ends_with($item, '[]')) {
 				if (is_iterable($value) && self::everyIs($value, substr($item, 0, -2))) {
 					return true;
@@ -152,7 +154,16 @@ class Validators
 			}
 
 			[$type] = $item = explode(':', $item, 2);
-			if (isset(static::$validators[$type])) {
+			if ($type === 'pattern') {
+				// A pattern may contain pipes, so the rest belongs to it and must not be
+				// split into further validators.
+				$pattern = implode('|', array_merge(array_slice($item, 1), array_slice($items, $i + 1)));
+				if (Strings::match($value, '~^(?:' . $pattern . ')$~D')) {
+					return true;
+				}
+
+				break;
+			} elseif (isset(static::$validators[$type])) {
 				try {
 					if (!static::$validators[$type]($value)) {
 						continue;
@@ -160,12 +171,6 @@ class Validators
 				} catch (\TypeError) {
 					continue;
 				}
-			} elseif ($type === 'pattern') {
-				if (Strings::match($value, '|^' . ($item[1] ?? '') . '$|D')) {
-					return true;
-				}
-
-				continue;
 			} elseif (!$value instanceof $type) {
 				continue;
 			}

--- a/tests/Utils/Validators.is().phpt
+++ b/tests/Utils/Validators.is().phpt
@@ -259,6 +259,25 @@ test('validates string against a regular expression pattern', function () {
 });
 
 
+test('allows pipe inside a regular expression pattern', function () {
+	// grouped alternation, https://github.com/nette/utils/issues/206
+	Assert::true(Validators::is('a', 'pattern:(a|b)'));
+	Assert::true(Validators::is('b', 'pattern:(a|b)'));
+	Assert::false(Validators::is('c', 'pattern:(a|b)'));
+
+	// bare alternation must no longer throw and is anchored as a whole
+	Assert::true(Validators::is('a', 'pattern:a|b'));
+	Assert::true(Validators::is('b', 'pattern:a|b'));
+	Assert::false(Validators::is('c', 'pattern:a|b'));
+	Assert::false(Validators::is('ab', 'pattern:a|b'));
+
+	// a pattern combined with other validators
+	Assert::true(Validators::is(5, 'int|pattern:(a|b)'));
+	Assert::true(Validators::is('a', 'int|pattern:(a|b)'));
+	Assert::false(Validators::is('c', 'int|pattern:(a|b)'));
+});
+
+
 test('ensures alphanumeric string meets minimum length', function () {
 	Assert::false(Validators::is('', 'alnum'));
 	Assert::false(Validators::is('a-1', 'alnum'));


### PR DESCRIPTION

## Problem

`Validators::is()` crashes on a valid pattern that contains a pipe:

```php
Validators::is('a', 'pattern:(a|b)');
// Nette\Utils\RegexpException: Compilation failed: missing closing parenthesis
// at offset 4 in pattern: |^(a$|D
```

The call should simply return `true`. This has been reported and confirmed valid
in nette/utils#206.

## Root cause (two intertwined parsing bugs)

`src/Utils/Validators.php`, method `is()`:

1. **Spec splitting** (was line ~140): `explode('|', $expected)` splits the whole
   expression on every `|`. It is meant to separate combined validators
   (`int|string`), but it also tears a regular expression apart, so
   `pattern:(a|b)` becomes the two tokens `pattern:(a` and `b)`.

2. **PCRE delimiter collision** (was line ~164):
   `Strings::match($value, '|^' . $pattern . '$|D')` uses `|` as the PCRE
   delimiter. Even without bug 1, any `|` in the user pattern would prematurely
   close the delimiter and produce an invalid regex.

Together they turn a valid pattern into `|^(a$|D`, which fails to compile and
throws `RegexpException`.

## Fix

- A `pattern:` argument now consumes the remaining part of the expression, so the
  pipes it contains are no longer treated as the validator separator. Combined
  forms such as `int|pattern:(a|b)` keep working because the pipe-as-OR semantics
  are preserved for every non-pattern validator.
- The PCRE delimiter is changed from `|` to `~`, which does not collide with the
  common alternation metacharacter. The pattern is additionally wrapped in a
  non-capturing group `^(?:...)$` so a bare alternation (`pattern:a|b`) is
  anchored as a whole instead of being read as `(^a)|(b$)`.

The `int|string`, `pattern:\d+` and empty `pattern` cases are unchanged.
